### PR TITLE
Remove golang 1.13 specific optional compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ operator:
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-operator cmd/manager/main.go
 
 csv-generator:
-	CGO_ENABLED=0 go build -trimpath -a -ldflags '-extldflags "-static"' -o _out/csv-generator tools/csv-generator.go
+	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/csv-generator tools/csv-generator.go
 
 image: operator
 	hack/version.sh _out; \


### PR DESCRIPTION
Signed-off-by: Adam Litke <alitke@redhat.com>