### PR TITLE
Don't manage storage class with operator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $ kubectl create -f https://raw.githubusercontent.com/kubevirt/hostpath-provisio
 ```
 Once the CustomResource has been created, the operator will deploy the provisioner as a DaemonSet on each node.
 
+### Storage Class
+The hostpath provisioner supports two volumeBindingModes, Immediate and WaitForFirstConsumer. In general WaitForFirstConsumer is preferred however this requires Kubernetes >= 1.12 and if one is running an older kubernetes that volumeBindingMode will not work. For this reason the operator will not create the StorageClass for you and you will have to do it yourself. Example storageclass yamls are available in [deploy](deploy) directory in this repository.
+
 ## SELinux
 On each node you will have to give the directory you specify in the CR the appropriate selinux rules by running the following (assuming you pick /var/hpvolumes as your PathConfig path):
 ```bash

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -110,7 +110,6 @@ rules:
   - list
   - get
   - watch
-  - create
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/deploy/storageclass-immediate.yaml
+++ b/deploy/storageclass-immediate.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath-provisioner
+provisioner: kubevirt.io/hostpath-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/deploy/storageclass-wffc.yaml
+++ b/deploy/storageclass-wffc.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath-provisioner
+provisioner: kubevirt.io/hostpath-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
1. Allows user to pick Immediate or WaitForFirstConsumer, so operator is useful for older kubernetes.
2. Allows user to pick the storage class name.

Signed-off-by: Alexander Wels <awels@redhat.com>