### PR TITLE
Add a MachineConfig file for SELinux-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,7 @@ On each node you will have to give the directory you specify in the CR the appro
 $ sudo chcon -t container_file_t -R /var/hpvolumes
 ```
 
+Another way to configure SELinux when using OpenShift is using a [MachineConfig](./contrib/machineconfig-selinux-hpp.yaml).
+
 ## Deployment in OpenShift
 The operator will create the appropriate SecurityContextConstraints for the hostpath provisioner to work and assign the ServiceAccount to that SCC. This operator will only work on OpenShift 4 and later (Kubernetes >= 1.12).

--- a/contrib/machineconfig-selinux-hpp.yaml
+++ b/contrib/machineconfig-selinux-hpp.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-set-selinux-for-hostpath-provisioner-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Set SELinux chcon for hostpath provisioner
+            Before=kubelet.service
+
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStartPre=-mkdir -p /var/hpvolumes
+            ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: hostpath-provisioner.service
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-set-selinux-for-hostpath-provisioner-worker
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Set SELinux chcon for hostpath provisioner
+            Before=kubelet.service
+
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStartPre=-mkdir -p /var/hpvolumes
+            ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: hostpath-provisioner.service


### PR DESCRIPTION
These used to reside in CDI as:
cluster-sync/okd-4.3/hpp-master-mc.yaml
cluster-sync/okd-4.3/hpp-worker-mc.yaml

Combine the two into one file and refer to them in the README.

---
I combined the two files "blindly" since I don't have an easily available
way of testing it. Hopefully it's fine and the description is right.