### PR TITLE
Explicitly set the node placement values when updating.

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -88,7 +88,7 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSet(reqLogger logr.Logger,
 	}
 
 	// More complicated values from the CR need to be explicitly set rather than merged automatically, because we want to propagate empty values.
-	merged = updateDaemonSetObject(cr, merged)
+	updateDaemonSetObject(cr, merged)
 
 	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
@@ -197,11 +197,9 @@ func createDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, provis
 }
 
 // updateDaemonSetObject returns a DaemonSet with values set from CR.
-func updateDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, orig runtime.Object) runtime.Object {
-	newDaemonSet := orig.(*appsv1.DaemonSet)
-	newDaemonSet.Spec.Template.Spec.NodeSelector = cr.Spec.Workloads.NodeSelector
-	newDaemonSet.Spec.Template.Spec.Tolerations = cr.Spec.Workloads.Tolerations
-	newDaemonSet.Spec.Template.Spec.Affinity = cr.Spec.Workloads.Affinity
-
-	return newDaemonSet.DeepCopyObject()
+func updateDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, object runtime.Object) {
+	daemonSet := object.(*appsv1.DaemonSet)
+	daemonSet.Spec.Template.Spec.NodeSelector = cr.Spec.Workloads.NodeSelector
+	daemonSet.Spec.Template.Spec.Tolerations = cr.Spec.Workloads.Tolerations
+	daemonSet.Spec.Template.Spec.Affinity = cr.Spec.Workloads.Affinity
 }


### PR DESCRIPTION
Merging doesn't have the right behaviour: we want the values in the
DaemonSet to be identical to the ones in the CR, even if those values
are empty.

Note that there's no unit testing for it, as the fake client appears
to suffer from the same Update merge behaviour, and setting to an
empty value fails.