### PR TITLE
Change how scheme is set up for openshift/api/security

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -111,7 +111,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := secv1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := secv1.Install(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/controller/hostpathprovisioner/contoller_test.go
+++ b/pkg/controller/hostpathprovisioner/contoller_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Controller reconcile loop", func() {
 		// Register operator types with the runtime scheme.
 		s := scheme.Scheme
 		s.AddKnownTypes(hppv1.SchemeGroupVersion, cr)
-		secv1.AddToScheme(s)
+		secv1.Install(s)
 
 		// Create a fake client to mock API calls.
 		cl := fake.NewFakeClient(objs...)
@@ -289,7 +289,7 @@ var _ = Describe("Controller reconcile loop", func() {
 		// Register operator types with the runtime scheme.
 		s := scheme.Scheme
 		s.AddKnownTypes(hppv1.SchemeGroupVersion, cr)
-		secv1.AddToScheme(s)
+		secv1.Install(s)
 
 		// Create a fake client to mock API calls.
 		cl := fake.NewFakeClient(objs...)
@@ -543,7 +543,7 @@ func createDeployedCr(cr *hppv1.HostPathProvisioner) (*hppv1.HostPathProvisioner
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
 	s.AddKnownTypes(hppv1.SchemeGroupVersion, cr)
-	secv1.AddToScheme(s)
+	secv1.Install(s)
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, objs...)


### PR DESCRIPTION
Currently SCCs are not being watched due to incorrect scheme setup of openshift/api/security:
https://github.com/openshift/api/blob/master/security/v1/register.go#L21-L22

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>