### PR TITLE
Handle upgrade scenario according to constant resource names

### DIFF
--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -22,24 +22,38 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	hostpathprovisionerv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
 )
 
 func (r *ReconcileHostPathProvisioner) reconcileClusterRoleBinding(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string, recorder record.EventRecorder) (reconcile.Result, error) {
+	// Previous versions created resources with names that depend on the CR, whereas now, we have fixed names for those.
+	// We will remove those and have the next loop create the resources with fixed names so we don't end up with two sets of hpp resources.
+	dups, err := r.getDuplicateClusterRoleBinding(cr.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	for _, dup := range dups {
+		if err := r.deleteClusterRoleBindingObject(dup.Name); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Define a new ClusterRoleBinding object
 	desired := createClusterRoleBindingObject(namespace)
 	setLastAppliedConfiguration(desired)
 	// Check if this ClusterRoleBinding already exists
 	found := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRoleBinding", "ClusterRoleBinding.Name", desired.Name)
 		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
@@ -112,29 +126,41 @@ func createClusterRoleBindingObject(namespace string) *rbacv1.ClusterRoleBinding
 	}
 }
 
-func (r *ReconcileHostPathProvisioner) deleteClusterRoleBindingObject() error {
+func (r *ReconcileHostPathProvisioner) deleteClusterRoleBindingObject(name string) error {
 	// Check if this ClusterRoleBinding still exists.
-	crb := &rbacv1.ClusterRoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, crb)
-	if err != nil && errors.IsNotFound(err) {
-		// Already gone, return
-		return nil
-	} else if err != nil {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := r.client.Delete(context.TODO(), crb); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// Delete ClusterRoleBinding
-	return r.client.Delete(context.TODO(), crb)
 
+	return nil
 }
 
 func (r *ReconcileHostPathProvisioner) reconcileClusterRole(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, recorder record.EventRecorder) (reconcile.Result, error) {
+	// Previous versions created resources with names that depend on the CR, whereas now, we have fixed names for those.
+	// We will remove those and have the next loop create the resources with fixed names so we don't end up with two sets of hpp resources.
+	dups, err := r.getDuplicateClusterRole(cr.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	for _, dup := range dups {
+		if err := r.deleteClusterRoleObject(dup.Name); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Define a new ClusterRole object
 	desired := createClusterRoleObject()
 	setLastAppliedConfiguration(desired)
 
 	// Check if this ClusterRole already exists
 	found := &rbacv1.ClusterRole{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRole", "ClusterRole.Name", desired.Name)
 		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
@@ -265,17 +291,65 @@ func createClusterRoleObject() *rbacv1.ClusterRole {
 	}
 }
 
-func (r *ReconcileHostPathProvisioner) deleteClusterRoleObject() error {
+func (r *ReconcileHostPathProvisioner) deleteClusterRoleObject(name string) error {
 	// Check if this ClusterRole still exists.
-	role := &rbacv1.ClusterRole{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, role)
-	if err != nil && errors.IsNotFound(err) {
-		// Already gone, return
-		return nil
-	} else if err != nil {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := r.client.Delete(context.TODO(), role); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// Delete ClusterRoleBinding
-	return r.client.Delete(context.TODO(), role)
 
+	return nil
+}
+
+// getDuplicateClusterRole will give us duplicate ClusterRoles from a previous version if they exist.
+// This is possible from a previous HPP version where the resources (DaemonSet, RBAC) were named depending on the CR, whereas now, we have fixed names for those.
+func (r *ReconcileHostPathProvisioner) getDuplicateClusterRole(customCrName string) ([]rbacv1.ClusterRole, error) {
+	crList := &rbacv1.ClusterRoleList{}
+	dups := make([]rbacv1.ClusterRole, 0)
+
+	ls, err := labels.Parse(fmt.Sprintf("k8s-app in (%s, %s)", MultiPurposeHostPathProvisionerName, customCrName))
+	if err != nil {
+		return dups, err
+	}
+	lo := &client.ListOptions{LabelSelector: ls}
+	if err := r.client.List(context.TODO(), crList, lo); err != nil {
+		return dups, err
+	}
+
+	for _, cr := range crList.Items {
+		if cr.Name != MultiPurposeHostPathProvisionerName {
+			dups = append(dups, cr)
+		}
+	}
+
+	return dups, nil
+}
+
+// getDuplicateClusterRoleBinding will give us duplicate ClusterRoleBindings from a previous version if they exist.
+// This is possible from a previous HPP version where the resources (DaemonSet, RBAC) were named depending on the CR, whereas now, we have fixed names for those.
+func (r *ReconcileHostPathProvisioner) getDuplicateClusterRoleBinding(customCrName string) ([]rbacv1.ClusterRoleBinding, error) {
+	crbList := &rbacv1.ClusterRoleBindingList{}
+	dups := make([]rbacv1.ClusterRoleBinding, 0)
+
+	ls, err := labels.Parse(fmt.Sprintf("k8s-app in (%s, %s)", MultiPurposeHostPathProvisionerName, customCrName))
+	if err != nil {
+		return dups, err
+	}
+	lo := &client.ListOptions{LabelSelector: ls}
+	if err := r.client.List(context.TODO(), crbList, lo); err != nil {
+		return dups, err
+	}
+
+	for _, crb := range crbList.Items {
+		if crb.Name != MultiPurposeHostPathProvisionerName {
+			dups = append(dups, crb)
+		}
+	}
+
+	return dups, nil
 }

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -25,11 +25,13 @@ import (
 	secv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	hostpathprovisionerv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
 )
@@ -39,13 +41,25 @@ func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraints(reqLo
 		return reconcile.Result{}, err
 	}
 
+	// Previous versions created resources with names that depend on the CR, whereas now, we have fixed names for those.
+	// We will remove those and have the next loop create the resources with fixed names so we don't end up with two sets of hpp resources.
+	dups, err := r.getDuplicateSecurityContextConstraints(cr.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	for _, dup := range dups {
+		if err := r.deleteSCC(dup.Name); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Define a new SecurityContextConstraints object
 	desired := createSecurityContextConstraintsObject(namespace)
 	setLastAppliedConfiguration(desired)
 
 	// Check if this SecurityContextConstraints already exists
 	found := &secv1.SecurityContextConstraints{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, found)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new SecurityContextConstraints", "SecurityContextConstraints.Name", desired.Name)
 		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
@@ -92,21 +106,22 @@ func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraints(reqLo
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileHostPathProvisioner) deleteSCC() error {
+func (r *ReconcileHostPathProvisioner) deleteSCC(name string) error {
 	if used, err := r.checkSCCUsed(); used == false {
 		return err
 	}
 	// Check if this SecurityContextConstraints already exists
-	scc := &secv1.SecurityContextConstraints{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, scc)
-	if err != nil && errors.IsNotFound(err) {
-		// Already gone, return
-		return nil
-	} else if err != nil {
+	scc := &secv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if err := r.client.Delete(context.TODO(), scc); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// Delete SCC
-	return r.client.Delete(context.TODO(), scc)
+
+	return nil
 }
 
 func createSecurityContextConstraintsObject(namespace string) *secv1.SecurityContextConstraints {
@@ -165,4 +180,28 @@ func (r *ReconcileHostPathProvisioner) checkSCCUsed() (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// getDuplicateSecurityContextConstraints will give us duplicate SecurityContextConstraints from a previous version if they exist.
+// This is possible from a previous HPP version where the resources (DaemonSet, RBAC) were named depending on the CR, whereas now, we have fixed names for those.
+func (r *ReconcileHostPathProvisioner) getDuplicateSecurityContextConstraints(customCrName string) ([]secv1.SecurityContextConstraints, error) {
+	sccList := &secv1.SecurityContextConstraintsList{}
+	dups := make([]secv1.SecurityContextConstraints, 0)
+
+	ls, err := labels.Parse(fmt.Sprintf("k8s-app in (%s, %s)", MultiPurposeHostPathProvisionerName, customCrName))
+	if err != nil {
+		return dups, err
+	}
+	lo := &client.ListOptions{LabelSelector: ls}
+	if err := r.client.List(context.TODO(), sccList, lo); err != nil {
+		return dups, err
+	}
+
+	for _, scc := range sccList.Items {
+		if scc.Name != MultiPurposeHostPathProvisionerName {
+			dups = append(dups, scc)
+		}
+	}
+
+	return dups, nil
 }

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2019 The hostpath provisioner operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostpathprovisioner
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	hostpathprovisionerv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
+)
+
+func (r *ReconcileHostPathProvisioner) reconcileServiceAccount(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
+	// Previous versions created resources with names that depend on the CR, whereas now, we have fixed names for those.
+	// We will remove those and have the next loop create the resources with fixed names so we don't end up with two sets of hpp resources.
+	dups, err := r.getDuplicateServiceAccount(cr.Name, namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	for _, dup := range dups {
+		if err := r.deleteServiceAccount(dup.Name, namespace); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Define a new Service Account object
+	desired := createServiceAccountObject(namespace)
+	setLastAppliedConfiguration(desired)
+
+	// Set HostPathProvisioner instance as the owner and controller
+	if err := controllerutil.SetControllerReference(cr, desired, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this ServiceAccount already exists
+	found := &corev1.ServiceAccount{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Service Account", "ServiceAccount.Namespace", desired.Namespace, "ServiceAccount.Name", desired.Name)
+		r.recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
+		err = r.client.Create(context.TODO(), desired)
+		if err != nil {
+			r.recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
+			return reconcile.Result{}, err
+		}
+
+		// Service Account created successfully - don't requeue
+		r.recorder.Event(cr, corev1.EventTypeNormal, createResourceSuccess, fmt.Sprintf(createMessageSucceeded, desired, desired.Name))
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged ServiceAccount from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// ServiceAccount already exists, check if we need to update.
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(log, currentRuntimeObjCopy, merged)
+		// Current is different from desired, update.
+		reqLogger.Info("Updating Service Account", "ServiceAccount.Name", desired.Name)
+		r.recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
+		err = r.client.Update(context.TODO(), merged)
+		if err != nil {
+			r.recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
+			return reconcile.Result{}, err
+		}
+		r.recorder.Event(cr, corev1.EventTypeNormal, updateResourceSuccess, fmt.Sprintf(updateMessageSucceeded, desired, desired.Name))
+		return reconcile.Result{}, nil
+	}
+
+	// Service Account already exists and matches desired - don't requeue
+	reqLogger.V(3).Info("Skip reconcile: Service Account already exists", "ServiceAccount.Namespace", found.Namespace, "ServiceAccount.Name", found.Name)
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileHostPathProvisioner) deleteServiceAccount(name, namespace string) error {
+	// Check if this ServiceAccount already exists
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	if err := r.client.Delete(context.TODO(), sa); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+// createServiceAccount returns a new Service Account object in the same namespace as the cr.
+func createServiceAccountObject(namespace string) *corev1.ServiceAccount {
+	labels := map[string]string{
+		"k8s-app": MultiPurposeHostPathProvisionerName,
+	}
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ControllerServiceAccountName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+}
+
+// getDuplicateServiceAccount will give us duplicate ServiceAccounts from a previous version if they exist.
+// This is possible from a previous HPP version where the resources (DaemonSet, RBAC) were named depending on the CR, whereas now, we have fixed names for those.
+func (r *ReconcileHostPathProvisioner) getDuplicateServiceAccount(customCrName, namespace string) ([]corev1.ServiceAccount, error) {
+	saList := &corev1.ServiceAccountList{}
+	dups := make([]corev1.ServiceAccount, 0)
+
+	ls, err := labels.Parse(fmt.Sprintf("k8s-app in (%s, %s)", MultiPurposeHostPathProvisionerName, customCrName))
+	if err != nil {
+		return dups, err
+	}
+	lo := &client.ListOptions{LabelSelector: ls, Namespace: namespace}
+	if err := r.client.List(context.TODO(), saList, lo); err != nil {
+		return dups, err
+	}
+
+	for _, sa := range saList.Items {
+		if sa.Name != ControllerServiceAccountName {
+			dups = append(dups, sa)
+		}
+	}
+
+	return dups, nil
+}


### PR DESCRIPTION
In https://github.com/kubevirt/hostpath-provisioner-operator/pull/106 we introduced constant resource names,
instead of resource names that depend on the CR's name.

This requires special handling in an upgrade scenario, where we might end up with two sets of hpp resources,
If user was using a custom CR name.

Example:
- Pre upgrade
CR name: "custom-hostpath-provisioner"
Resource names: DaemonSet called "custom-hostpath-provisioner", SA "custom-hostpath-provisioner-admin"
- Post upgrade
SA, DS now have fixed names ("hostpath-provisioner", "hostpath-provisioner-admin").
They don't exist, we proceed to create them
We now have 2 DaemonSets acting on PVCs.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>