### PR TITLE
Handle upgrade unable to delete duplicate set of resources

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -140,13 +140,6 @@ rules:
   - get
   - watch
   - create
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  resourceNames:
-  - hostpath-provisioner
-  verbs:
   - delete
   - update
 - apiGroups:
@@ -166,19 +159,8 @@ rules:
   - ""
   resources:
   - serviceaccounts
-  resourceNames:
-  - hostpath-provisioner-admin
   verbs:
   - '*'
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - list
-  - get
-  - watch
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -893,6 +893,14 @@ func createServiceAccountWithNameThatDependsOnCr() *corev1.ServiceAccount {
 			Name:      "test-name-admin",
 			Namespace: "test-namespace",
 			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "hostpathprovisioner.kubevirt.io/test",
+					Kind:       "HostPathProvisioner",
+					Name:       "test-name",
+					UID:        "1234",
+				},
+			},
 		},
 	}
 }

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -233,7 +233,12 @@ func (r *ReconcileHostPathProvisioner) getDuplicateDaemonSet(customCrName, names
 
 	for _, ds := range dsList.Items {
 		if ds.Name != MultiPurposeHostPathProvisionerName {
-			dups = append(dups, ds)
+			for _, ownerRef := range ds.OwnerReferences {
+				if ownerRef.Kind == "HostPathProvisioner" && ownerRef.Name == customCrName {
+					dups = append(dups, ds)
+					break
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -154,7 +154,12 @@ func (r *ReconcileHostPathProvisioner) getDuplicateServiceAccount(customCrName, 
 
 	for _, sa := range saList.Items {
 		if sa.Name != ControllerServiceAccountName {
-			dups = append(dups, sa)
+			for _, ownerRef := range sa.OwnerReferences {
+				if ownerRef.Kind == "HostPathProvisioner" && ownerRef.Name == customCrName {
+					dups = append(dups, sa)
+					break
+				}
+			}
 		}
 	}
 

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -340,19 +340,6 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 				"get",
 				"watch",
 				"create",
-			},
-		},
-		{
-			APIGroups: []string{
-				"apps",
-			},
-			Resources: []string{
-				"daemonsets",
-			},
-			ResourceNames: []string{
-				"hostpath-provisioner",
-			},
-			Verbs: []string{
 				"delete",
 				"update",
 			},
@@ -387,25 +374,8 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 			Resources: []string{
 				"serviceaccounts",
 			},
-			ResourceNames: []string{
-				"hostpath-provisioner-admin",
-			},
 			Verbs: []string{
 				"*",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"serviceaccounts",
-			},
-			Verbs: []string{
-				"list",
-				"get",
-				"watch",
-				"create",
 			},
 		},
 	}


### PR DESCRIPTION
Upon uprade with custom CR name, was failing to cleanup the extra set of resources
that are name dependent (context in #106).

The issue was that we only give delete permissions to the fixed names,
and hence we cant expect the operator to be able to delete the old duplicate set.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>