### PR TITLE
Add relationship labels

### DIFF
--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -28,6 +28,19 @@ const (
 	ControllerServiceAccountName = "hostpath-provisioner-admin"
 	// MultiPurposeHostPathProvisionerName is the name used for the DaemonSet, ClusterRole/Binding, SCC and k8s-app label value.
 	MultiPurposeHostPathProvisionerName = "hostpath-provisioner"
+	// PartOfLabelEnvVarName is the environment variable name for the part-of label value
+	PartOfLabelEnvVarName = "INSTALLER_PART_OF_LABEL"
+	// VersionLabelEnvVarName is the environment variable name for the version label value
+	VersionLabelEnvVarName = "INSTALLER_VERSION_LABEL"
+
+	// AppKubernetesPartOfLabel is the Kubernetes recommended part-of label
+	AppKubernetesPartOfLabel = "app.kubernetes.io/part-of"
+	// AppKubernetesVersionLabel is the Kubernetes recommended version label
+	AppKubernetesVersionLabel = "app.kubernetes.io/version"
+	// AppKubernetesManagedByLabel is the Kubernetes recommended managed-by label
+	AppKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
+	// AppKubernetesComponentLabel is the Kubernetes recommended component label
+	AppKubernetesComponentLabel = "app.kubernetes.io/component"
 
 	createResourceStart   = "CreateResourceStart"
 	createResourceFailed  = "CreateResourceFailed"

--- a/pkg/controller/hostpathprovisioner/controller_suite_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_suite_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package hostpathprovisioner
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -26,6 +27,13 @@ import (
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(logf.ZapLoggerTo(GinkgoWriter, true))
+	os.Setenv(PartOfLabelEnvVarName, "testing")
+	os.Setenv(VersionLabelEnvVarName, "v0.0.0-tests")
+})
+
+var _ = AfterSuite(func() {
+	os.Unsetenv(PartOfLabelEnvVarName)
+	os.Unsetenv(VersionLabelEnvVarName)
 })
 
 func TestHostpathProvisioners(t *testing.T) {

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -734,6 +734,8 @@ func verifyCreateDaemonSet(cl client.Client) {
 	Expect(ds.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("false"))
 	// Check directory
 	Expect(ds.Spec.Template.Spec.Containers[0].Env[2].Value).To(Equal("/tmp/test"))
+	// Check k8s recommended labels
+	Expect(ds.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func verifyCreateServiceAccount(cl client.Client) {
@@ -745,6 +747,7 @@ func verifyCreateServiceAccount(cl client.Client) {
 	err := cl.Get(context.TODO(), nn, sa)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(sa.ObjectMeta.Name).To(Equal(ControllerServiceAccountName))
+	Expect(sa.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func verifyCreateClusterRole(cl client.Client) {
@@ -825,6 +828,7 @@ func verifyCreateClusterRole(cl client.Client) {
 		},
 	}
 	Expect(crole.Rules).To(Equal(expectedRules))
+	Expect(crole.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func verifyCreateClusterRoleBinding(cl client.Client) {
@@ -836,6 +840,7 @@ func verifyCreateClusterRoleBinding(cl client.Client) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(crb.Subjects[0].Name).To(Equal(ControllerServiceAccountName))
 	Expect(crb.Subjects[0].Namespace).To(Equal("test-namespace"))
+	Expect(crb.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func verifyCreateSCC(cl client.Client) {
@@ -883,6 +888,7 @@ func verifyCreateSCC(cl client.Client) {
 		},
 	}
 	Expect(scc).To(Equal(expected))
+	Expect(scc.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func createServiceAccountWithNameThatDependsOnCr() *corev1.ServiceAccount {

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -139,9 +139,7 @@ func copyStatusFields(desired, current *appsv1.DaemonSet) *appsv1.DaemonSet {
 func createDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, reqLogger logr.Logger, provisionerImage, namespace string) *appsv1.DaemonSet {
 	reqLogger.Info("CR nodeselector", "nodeselector", cr.Spec.Workloads)
 	volumeType := corev1.HostPathDirectoryOrCreate
-	labels := map[string]string{
-		"k8s-app": MultiPurposeHostPathProvisionerName,
-	}
+	labels := getRecommendedLabels()
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -184,6 +182,24 @@ func createDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, reqLog
 								{
 									Name:  "PV_DIR",
 									Value: cr.Spec.PathConfig.Path,
+								},
+								{
+									Name: "INSTALLER_PART_OF_LABEL",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.labels['app.kubernetes.io/part-of']",
+										},
+									},
+								},
+								{
+									Name: "INSTALLER_VERSION_LABEL",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.labels['app.kubernetes.io/version']",
+										},
+									},
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -89,9 +89,7 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleBinding(reqLogger log
 }
 
 func createClusterRoleBindingObject(namespace string) *rbacv1.ClusterRoleBinding {
-	labels := map[string]string{
-		"k8s-app": MultiPurposeHostPathProvisionerName,
-	}
+	labels := getRecommendedLabels()
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   MultiPurposeHostPathProvisionerName,
@@ -184,9 +182,7 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRole(reqLogger logr.Logge
 }
 
 func createClusterRoleObject() *rbacv1.ClusterRole {
-	labels := map[string]string{
-		"k8s-app": MultiPurposeHostPathProvisionerName,
-	}
+	labels := getRecommendedLabels()
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   MultiPurposeHostPathProvisionerName,

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -112,9 +112,7 @@ func (r *ReconcileHostPathProvisioner) deleteSCC(name string) error {
 
 func createSecurityContextConstraintsObject(namespace string) *secv1.SecurityContextConstraints {
 	saName := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, ControllerServiceAccountName)
-	labels := map[string]string{
-		"k8s-app": MultiPurposeHostPathProvisionerName,
-	}
+	labels := getRecommendedLabels()
 	return &secv1.SecurityContextConstraints{
 		Groups: []string{},
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -125,9 +125,7 @@ func (r *ReconcileHostPathProvisioner) deleteServiceAccount(name, namespace stri
 
 // createServiceAccount returns a new Service Account object in the same namespace as the cr.
 func createServiceAccountObject(namespace string) *corev1.ServiceAccount {
-	labels := map[string]string{
-		"k8s-app": MultiPurposeHostPathProvisionerName,
-	}
+	labels := getRecommendedLabels()
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ControllerServiceAccountName,

--- a/pkg/controller/hostpathprovisioner/util.go
+++ b/pkg/controller/hostpathprovisioner/util.go
@@ -19,6 +19,7 @@ package hostpathprovisioner
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 
 	jsondiff "github.com/appscode/jsonpatch"
@@ -132,4 +133,24 @@ func setLastAppliedConfiguration(obj metav1.Object) error {
 	obj.GetAnnotations()[lastAppliedConfigAnnotation] = string(bytes)
 
 	return nil
+}
+
+func getRecommendedLabels() map[string]string {
+	labels := map[string]string{
+		"k8s-app":                   MultiPurposeHostPathProvisionerName,
+		AppKubernetesManagedByLabel: "hostpath-provisioner-operator",
+		AppKubernetesComponentLabel: "storage",
+	}
+
+	// Populate installer labels from env vars
+	partOfLabelVal := os.Getenv(PartOfLabelEnvVarName)
+	if partOfLabelVal != "" {
+		labels[AppKubernetesPartOfLabel] = partOfLabelVal
+	}
+	versionLabelVal := os.Getenv(VersionLabelEnvVarName)
+	if versionLabelVal != "" {
+		labels[AppKubernetesVersionLabel] = versionLabelVal
+	}
+
+	return labels
 }

--- a/tools/helper/helper.go
+++ b/tools/helper/helper.go
@@ -124,6 +124,22 @@ func CreateOperatorEnvVar(repo, deployClusterResources, operatorImage, provision
 			Name:  "PULL_POLICY",
 			Value: pullPolicy,
 		},
+		{
+			Name: "INSTALLER_PART_OF_LABEL",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['app.kubernetes.io/part-of']",
+				},
+			},
+		},
+		{
+			Name: "INSTALLER_VERSION_LABEL",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['app.kubernetes.io/version']",
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
We should be able to tell if we're part of a broader installation,
and also make sure no resources of ours seem like :alien: to the user.

Will follow up in https://github.com/kubevirt/hostpath-provisioner
to make sure our PVs are labeled with those as well.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>