### PR TITLE
Don't reconcile over spec.selector changes

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -89,6 +89,8 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSet(reqLogger logr.Logger,
 	currentRuntimeObjCopy := found.DeepCopyObject()
 	// Copy found status fields, so the compare won't fail on desired/scheduled/ready pods being different. Updating will ignore them anyway.
 	desired = copyStatusFields(desired, found)
+	// Leave out spec.selector updates; this section is a minimal set that is needed to know which pods are under our governance, and is immutable
+	desired.Spec.Selector = found.Spec.Selector.DeepCopy()
 
 	// allow users to add new annotations (but not change ours)
 	mergeLabelsAndAnnotations(desired, found)


### PR DESCRIPTION
Currently upgrade is failing because latest is adding labels (https://github.com/kubevirt/hostpath-provisioner-operator/pull/114) to spec.selector.
In any case it would not make sense to reconcile this field, as:
- It is immutable
- spec.selector is a minimal set that is needed to know which pods are under our governance,
while spec.template.metadata.labels can have extra labels which we can label the pods with.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>