### PR TITLE
Modify operator to deploy both legacy and csi driver by default.

### DIFF
--- a/deploy/hostpathprovisioner_cr.yaml
+++ b/deploy/hostpathprovisioner_cr.yaml
@@ -3,7 +3,6 @@ kind: HostPathProvisioner
 metadata:
   name: hostpath-provisioner
 spec:
-  disableCsi: true
   imagePullPolicy: IfNotPresent
   pathConfig:
     path: "/var/hpvolumes"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -42,6 +42,7 @@ rules:
   resourceNames:
   - hostpath-provisioner
   - hostpath-provisioner-admin
+  - hostpath-provisioner-admin-csi
   - hostpath-provisioner-health-check
   verbs:
   - update
@@ -71,6 +72,7 @@ rules:
   resourceNames:
   - hostpath-provisioner
   - hostpath-provisioner-admin
+  - hostpath-provisioner-admin-csi
   - hostpath-provisioner-health-check
   verbs:
   - update
@@ -193,6 +195,7 @@ rules:
   - daemonsets
   resourceNames:
   - hostpath-provisioner
+  - hostpath-provisioner-csi
   verbs:
   - delete
   - update
@@ -224,6 +227,7 @@ rules:
   - serviceaccounts
   resourceNames:
   - hostpath-provisioner-admin
+  - hostpath-provisioner-admin-csi
   verbs:
   - 'update'
   - 'delete'
@@ -262,7 +266,9 @@ rules:
   resources:
   - rolebindings
   resourceNames:
+  - hostpath-provisioner
   - hostpath-provisioner-admin
+  - hostpath-provisioner-admin-csi
   - hostpath-provisioner-health-check
   verbs:
   - update
@@ -272,7 +278,9 @@ rules:
   resources:
   - roles
   resourceNames:
+  - hostpath-provisioner
   - hostpath-provisioner-admin
+  - hostpath-provisioner-admin-csi
   - hostpath-provisioner-health-check
   verbs:
   - update
@@ -1893,7 +1901,7 @@ spec:
             - name: PROVISIONER_IMAGE
               value: "quay.io/kubevirt/hostpath-provisioner:latest"
             - name: CSI_PROVISIONER_IMAGE
-              value: "quay.io/kubevirt/hostpath-provisioner-csi:latest"
+              value: "quay.io/kubevirt/hostpath-csi-driver:latest"
             - name: EXTERNAL_HEALTH_MON_IMAGE
               value: "k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
             - name: NODE_DRIVER_REG_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -667,10 +667,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -767,10 +830,71 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
@@ -867,10 +991,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -967,10 +1154,71 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
@@ -1096,6 +1344,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
+        description: HostPathProvisioner is the Schema for the hostpathprovisioners
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1112,10 +1362,6 @@ spec:
           spec:
             description: HostPathProvisionerSpec defines the desired state of HostPathProvisioner
             properties:
-              disableCsi:
-                description: 'DisableCSI Use old in tree based provisioner instead
-                  of CSI provisioner, default: false'
-                type: boolean
               imagePullPolicy:
                 description: ImagePullPolicy is the container pull policy for the
                   host path provisioner containers
@@ -1434,10 +1680,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -1534,10 +1843,71 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
@@ -1634,10 +2004,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -1734,10 +2167,71 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array

--- a/deploy/storageclass-wffc-csi.yaml
+++ b/deploy/storageclass-wffc-csi.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: hostpath-provisioner
+  name: hostpath-csi
 provisioner: kubevirt.io.hostpath-provisioner
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
@@ -31,8 +31,6 @@ type HostPathProvisionerSpec struct {
 	PathConfig PathConfig `json:"pathConfig" valid:"required"`
 	// Restrict on which nodes HPP workload pods will be scheduled
 	Workload NodePlacement `json:"workload,omitempty"`
-	// DisableCSI Use old in tree based provisioner instead of CSI provisioner, default: false
-	DisableCsi bool `json:"disableCsi,omitempty"`
 }
 
 // HostPathProvisionerStatus defines the observed state of HostPathProvisioner

--- a/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
@@ -112,13 +112,6 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisionerSpec(ref com
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.NodePlacement"),
 						},
 					},
-					"disableCsi": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DisableCSI Use old in tree based provisioner instead of CSI provisioner, default: false",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
 				Required: []string{"pathConfig"},
 			},

--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -64,19 +64,15 @@ const (
 	// AppKubernetesComponentLabel is the Kubernetes recommended component label
 	AppKubernetesComponentLabel = "app.kubernetes.io/component"
 
-	createResourceStart   = "CreateResourceStart"
 	createResourceFailed  = "CreateResourceFailed"
 	createResourceSuccess = "CreateResourceSuccess"
 
-	updateResourceStart   = "UpdateResourceStart"
 	updateResourceFailed  = "UpdateResourceFailed"
 	updateResourceSuccess = "UpdateResourceSuccess"
 
-	createMessageStart     = "Started creation of resource %T %s"
 	createMessageFailed    = "Failed to create resource %s, %v"
 	createMessageSucceeded = "Successfully created resource %T %s"
 
-	updateMessageStart     = "Started update of resource %T %s"
 	updateMessageFailed    = "Failed to update resource %s, %v"
 	updateMessageSucceeded = "Successfully updated resource %T %s"
 

--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -44,7 +44,10 @@ const (
 	OperatorServiceAccountName = "hostpath-provisioner-operator"
 	// ProvisionerServiceAccountName is the name of Service Account used to run the controller.
 	ProvisionerServiceAccountName = "hostpath-provisioner-admin"
-	healthCheckName               = "hostpath-provisioner-health-check"
+	// ProvisionerServiceAccountNameCsi is the name of Service Account used to run the csi driver.
+	ProvisionerServiceAccountNameCsi = "hostpath-provisioner-admin-csi"
+
+	healthCheckName = "hostpath-provisioner-health-check"
 	// MultiPurposeHostPathProvisionerName is the name used for the DaemonSet, ClusterRole/Binding, SCC and k8s-app label value.
 	MultiPurposeHostPathProvisionerName = "hostpath-provisioner"
 	// PartOfLabelEnvVarName is the environment variable name for the part-of label value

--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -197,11 +197,7 @@ func (r *ReconcileHostPathProvisioner) Reconcile(context context.Context, reques
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	if !cr.Spec.DisableCsi {
-		reqLogger.Info("Reconciling CSI and legacy controller plugin")
-	} else {
-		reqLogger.Info("Reconciling legacy controller, this controller is deprecated")
-	}
+	reqLogger.Info("Reconciling CSI and legacy controller plugin")
 
 	namespace, err := watchNamespaceFunc()
 	if err != nil {

--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -425,12 +425,12 @@ func (r *ReconcileHostPathProvisioner) checkDegraded(logger logr.Logger, cr *hos
 		return true, err
 	}
 	daemonSetCsi := &appsv1.DaemonSet{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName), Namespace: namespace}, daemonSet)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName), Namespace: namespace}, daemonSetCsi)
 	if err != nil {
 		return true, err
 	}
 
-	if !checkDaemonSetReady(daemonSet) || checkDaemonSetReady(daemonSetCsi) {
+	if !(checkDaemonSetReady(daemonSet) && checkDaemonSetReady(daemonSetCsi)) {
 		degraded = true
 	}
 

--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileHostPathProvisioner) Reconcile(context context.Context, reques
 		return reconcile.Result{}, err
 	}
 	if !cr.Spec.DisableCsi {
-		reqLogger.Info("Reconciling CSI plugin")
+		reqLogger.Info("Reconciling CSI and legacy controller plugin")
 	} else {
 		reqLogger.Info("Reconciling legacy controller, this controller is deprecated")
 	}
@@ -304,7 +304,7 @@ func (r *ReconcileHostPathProvisioner) Reconcile(context context.Context, reques
 }
 
 func (r *ReconcileHostPathProvisioner) deleteAllRbac(reqLogger logr.Logger, namespace string) (reconcile.Result, error) {
-	for _, name := range []string{ProvisionerServiceAccountName, healthCheckName} {
+	for _, name := range []string{ProvisionerServiceAccountName, ProvisionerServiceAccountNameCsi, healthCheckName, MultiPurposeHostPathProvisionerName} {
 		reqLogger.Info("Deleting ClusterRoleBinding", "ClusterRoleBinding", name)
 		if err := r.deleteClusterRoleBindingObject(name); err != nil {
 			reqLogger.Error(err, "Unable to delete ClusterRoleBinding")

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -405,6 +405,18 @@ var _ = Describe("Controller reconcile loop", func() {
 		ds.Status.DesiredNumberScheduled = 2
 		err = cl.Update(context.TODO(), ds)
 		Expect(err).NotTo(HaveOccurred())
+		// Now make the csi daemonSet available, and reconcile again.
+		dsCsi := &appsv1.DaemonSet{}
+		dsNNCsi := types.NamespacedName{
+			Name:      fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),
+			Namespace: "test-namespace",
+		}
+		err = cl.Get(context.TODO(), dsNNCsi, dsCsi)
+		Expect(err).NotTo(HaveOccurred())
+		dsCsi.Status.NumberReady = 1
+		dsCsi.Status.DesiredNumberScheduled = 2
+		err = cl.Update(context.TODO(), dsCsi)
+		Expect(err).NotTo(HaveOccurred())
 
 		res, err = r.Reconcile(context.TODO(), req)
 		Expect(err).NotTo(HaveOccurred())
@@ -428,6 +440,17 @@ var _ = Describe("Controller reconcile loop", func() {
 		ds.Status.NumberReady = 2
 		ds.Status.DesiredNumberScheduled = 2
 		err = cl.Update(context.TODO(), ds)
+		Expect(err).NotTo(HaveOccurred())
+		dsCsi = &appsv1.DaemonSet{}
+		dsNNCsi = types.NamespacedName{
+			Name:      fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),
+			Namespace: "test-namespace",
+		}
+		err = cl.Get(context.TODO(), dsNNCsi, dsCsi)
+		Expect(err).NotTo(HaveOccurred())
+		dsCsi.Status.NumberReady = 2
+		dsCsi.Status.DesiredNumberScheduled = 2
+		err = cl.Update(context.TODO(), dsCsi)
 		Expect(err).NotTo(HaveOccurred())
 
 		res, err = r.Reconcile(context.TODO(), req)
@@ -731,6 +754,19 @@ func createDeployedCr(cr *hppv1.HostPathProvisioner) (*hppv1.HostPathProvisioner
 	ds.Status.NumberReady = 2
 	ds.Status.DesiredNumberScheduled = 2
 	err = cl.Update(context.TODO(), ds)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Now make the csi daemonSet available, and reconcile again.
+	dsCsi := &appsv1.DaemonSet{}
+	dsNNCsi := types.NamespacedName{
+		Name:      fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),
+		Namespace: "test-namespace",
+	}
+	err = cl.Get(context.TODO(), dsNNCsi, dsCsi)
+	Expect(err).NotTo(HaveOccurred())
+	dsCsi.Status.NumberReady = 2
+	dsCsi.Status.DesiredNumberScheduled = 2
+	err = cl.Update(context.TODO(), dsCsi)
 	Expect(err).NotTo(HaveOccurred())
 
 	// daemonSet is ready, now reconcile again. We should have condition changes and observed version should be set.

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -77,16 +77,13 @@ var _ = Describe("Controller reconcile loop", func() {
 		}
 	})
 
-	table.DescribeTable("Should create new everything if nothing exist", func(DisableCsi bool) {
-		cr.Spec.DisableCsi = DisableCsi
+	table.DescribeTable("Should create new everything if nothing exist", func() {
 		createDeployedCr(cr)
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
-	table.DescribeTable("Should fix a changed daemonSet", func(DisableCsi bool) {
-		cr.Spec.DisableCsi = DisableCsi
+	table.DescribeTable("Should fix a changed daemonSet", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test-name",
@@ -120,12 +117,10 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes[0].Name).To(Equal("pv-volume"))
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
-	table.DescribeTable("Should fix a changed service account", func(DisableCsi bool) {
-		cr.Spec.DisableCsi = DisableCsi
+	table.DescribeTable("Should fix a changed service account", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test-name",
@@ -159,12 +154,10 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sa.ObjectMeta.Labels["k8s-app"]).To(Equal(MultiPurposeHostPathProvisionerName))
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
-	table.DescribeTable("Should fix a changed ClusterRole", func(DisableCsi bool) {
-		cr.Spec.DisableCsi = DisableCsi
+	table.DescribeTable("Should fix a changed ClusterRole", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test-name",
@@ -200,12 +193,10 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(crole.Rules[1].Verbs)).To(Equal(4))
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
-	table.DescribeTable("Should fix a changed ClusterRoleBinding", func(DisableCsi bool) {
-		cr.Spec.DisableCsi = DisableCsi
+	table.DescribeTable("Should fix a changed ClusterRoleBinding", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test-name",
@@ -240,11 +231,10 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crb.Subjects[0].Name).To(Equal(ProvisionerServiceAccountNameCsi))
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
-	table.DescribeTable("Should fix a changed SecurityContextConstraints", func(disableCsi bool) {
+	table.DescribeTable("Should fix a changed SecurityContextConstraints", func() {
 		req := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test-name",
@@ -278,8 +268,7 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(scc.AllowPrivilegedContainer).To(BeFalse())
 		Expect(scc.Volumes).To(ContainElements(secv1.FSTypeHostPath, secv1.FSTypeSecret, secv1.FSProjected))
 	},
-		table.Entry("Disable CSI", true),
-		table.Entry("Enable CSI", false),
+		table.Entry("Enable CSI"),
 	)
 
 	It("Should requeue if watch namespaces returns error", func() {
@@ -741,7 +730,7 @@ func createDeployedCr(cr *hppv1.HostPathProvisioner) (*hppv1.HostPathProvisioner
 	verifyCreateCSIRole(r.client)
 	verifyCreateCSIRoleBinding(r.client)
 	verifyCreateCSIDriver(r.client)
-	verifyCreateSCC(r.client, cr.Spec.DisableCsi)
+	verifyCreateSCC(r.client)
 
 	// Now make the daemonSet available, and reconcile again.
 	ds := &appsv1.DaemonSet{}
@@ -1233,7 +1222,7 @@ func verifyCreateCSIRoleBinding(cl client.Client) {
 	Expect(rb.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
-func verifyCreateSCC(cl client.Client, disableCsi bool) {
+func verifyCreateSCC(cl client.Client) {
 	scc := &secv1.SecurityContextConstraints{}
 	nn := types.NamespacedName{
 		Name: fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),

--- a/pkg/controller/hostpathprovisioner/csidriver.go
+++ b/pkg/controller/hostpathprovisioner/csidriver.go
@@ -38,14 +38,6 @@ const (
 )
 
 func (r *ReconcileHostPathProvisioner) reconcileCSIDriver(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string, recorder record.EventRecorder) (reconcile.Result, error) {
-	if cr.Spec.DisableCsi {
-		if err := r.deleteCSIDriver(); err != nil {
-			return reconcile.Result{}, err
-		}
-		// Skip if CSI is not in use
-		return reconcile.Result{}, nil
-	}
-
 	// Define a new SecurityContextConstraints object
 	desired := createCSIDriverObject(namespace)
 	setLastAppliedConfiguration(desired)

--- a/pkg/controller/hostpathprovisioner/csidriver.go
+++ b/pkg/controller/hostpathprovisioner/csidriver.go
@@ -47,7 +47,6 @@ func (r *ReconcileHostPathProvisioner) reconcileCSIDriver(reqLogger logr.Logger,
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: driverName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new CSI Driver", "CSIDriver.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -77,7 +76,6 @@ func (r *ReconcileHostPathProvisioner) reconcileCSIDriver(reqLogger logr.Logger,
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating CSIDriver", "CSIDriver.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -99,7 +99,6 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSetForSa(reqLogger logr.Lo
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", desired.Namespace, "Daemonset.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -127,7 +126,6 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSetForSa(reqLogger logr.Lo
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, found)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating DaemonSet", "DaemonSet.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), found)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -140,10 +140,10 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSetForSa(reqLogger logr.Lo
 	return reconcile.Result{}, nil
 }
 
-func getDaemonSetArgs(reqLogger logr.Logger, namespace string, disableCsi bool) *daemonSetArgs {
+func getDaemonSetArgs(reqLogger logr.Logger, namespace string, legacyProvisioner bool) *daemonSetArgs {
 	res := &daemonSetArgs{}
 
-	if disableCsi {
+	if legacyProvisioner {
 		res.name = MultiPurposeHostPathProvisionerName
 		res.provisionerImage = os.Getenv(provisionerImageEnvVarName)
 		if res.provisionerImage == "" {

--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -59,7 +59,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleBindingForSa(reqLogge
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRoleBinding", "ClusterRoleBinding.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -90,7 +89,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleBindingForSa(reqLogge
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating ClusterRoleBinding", "ClusterRoleBinding.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
@@ -165,7 +163,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleForSa(reqLogger logr.
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new ClusterRole", "ClusterRole.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -196,7 +193,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleForSa(reqLogger logr.
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating ClusterRole", "ClusterRole.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
@@ -520,7 +516,6 @@ func (r *ReconcileHostPathProvisioner) reconcileRoleBindingForSa(reqLogger logr.
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new RoleBinding", "RoleBinding.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -551,7 +546,6 @@ func (r *ReconcileHostPathProvisioner) reconcileRoleBindingForSa(reqLogger logr.
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating RoleBinding", "RoleBinding.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
@@ -609,7 +603,6 @@ func (r *ReconcileHostPathProvisioner) reconcileRoleForSa(reqLogger logr.Logger,
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new Role", "Role.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -640,7 +633,6 @@ func (r *ReconcileHostPathProvisioner) reconcileRoleForSa(reqLogger logr.Logger,
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating Role", "Role.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -147,12 +147,10 @@ func createSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathPr
 			saName,
 		},
 	}
-	if cr.Spec.DisableCsi {
-		res.Volumes = []secv1.FSType{
-			secv1.FSTypeHostPath,
-			secv1.FSTypeSecret,
-			secv1.FSProjected,
-		}
+	res.Volumes = []secv1.FSType{
+		secv1.FSTypeHostPath,
+		secv1.FSTypeSecret,
+		secv1.FSProjected,
 	}
 	return res
 }

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -38,14 +38,19 @@ func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraints(reqLo
 	if used, err := r.checkSCCUsed(); used == false {
 		return reconcile.Result{}, err
 	}
+	if res, err := r.reconcileSecurityContextConstraintsDesired(reqLogger, cr, createSecurityContextConstraintsObject(cr, namespace), namespace, recorder); err != nil {
+		return res, err
+	}
+	return r.reconcileSecurityContextConstraintsDesired(reqLogger, cr, createCsiSecurityContextConstraintsObject(cr, namespace), namespace, recorder)
+}
 
+func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraintsDesired(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, desired *secv1.SecurityContextConstraints, namespace string, recorder record.EventRecorder) (reconcile.Result, error) {
 	// Define a new SecurityContextConstraints object
-	desired := createSecurityContextConstraintsObject(cr, namespace)
 	setLastAppliedConfiguration(desired)
 
 	// Check if this SecurityContextConstraints already exists
 	found := &secv1.SecurityContextConstraints{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: MultiPurposeHostPathProvisionerName}, found)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new SecurityContextConstraints", "SecurityContextConstraints.Name", desired.Name)
 		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
@@ -112,7 +117,6 @@ func (r *ReconcileHostPathProvisioner) deleteSCC(name string) error {
 
 func createSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) *secv1.SecurityContextConstraints {
 	saName := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, ProvisionerServiceAccountName)
-	labels := getRecommendedLabels()
 	res := &secv1.SecurityContextConstraints{
 		Groups: []string{},
 		TypeMeta: metav1.TypeMeta{
@@ -121,9 +125,9 @@ func createSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathPr
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   MultiPurposeHostPathProvisionerName,
-			Labels: labels,
+			Labels: getRecommendedLabels(),
 		},
-		AllowPrivilegedContainer: !cr.Spec.DisableCsi,
+		AllowPrivilegedContainer: false,
 		RequiredDropCapabilities: []corev1.Capability{
 			"KILL",
 			"MKNOD",
@@ -142,7 +146,7 @@ func createSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathPr
 		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
 			Type: secv1.SupplementalGroupsStrategyRunAsAny,
 		},
-		AllowHostDirVolumePlugin: cr.Spec.DisableCsi,
+		AllowHostDirVolumePlugin: true,
 		Users: []string{
 			saName,
 		},
@@ -153,6 +157,44 @@ func createSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathPr
 		secv1.FSProjected,
 	}
 	return res
+}
+
+func createCsiSecurityContextConstraintsObject(cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) *secv1.SecurityContextConstraints {
+	saName := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, ProvisionerServiceAccountNameCsi)
+	return &secv1.SecurityContextConstraints{
+		Groups: []string{},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "security.openshift.io/v1",
+			Kind:       "SecurityContextConstraints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),
+			Labels: getRecommendedLabels(),
+		},
+		AllowPrivilegedContainer: true,
+		RequiredDropCapabilities: []corev1.Capability{
+			"KILL",
+			"MKNOD",
+			"SETUID",
+			"SETGID",
+		},
+		RunAsUser: secv1.RunAsUserStrategyOptions{
+			Type: secv1.RunAsUserStrategyRunAsAny,
+		},
+		SELinuxContext: secv1.SELinuxContextStrategyOptions{
+			Type: secv1.SELinuxStrategyRunAsAny,
+		},
+		FSGroup: secv1.FSGroupStrategyOptions{
+			Type: secv1.FSGroupStrategyRunAsAny,
+		},
+		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
+			Type: secv1.SupplementalGroupsStrategyRunAsAny,
+		},
+		AllowHostDirVolumePlugin: false,
+		Users: []string{
+			saName,
+		},
+	}
 }
 
 func (r *ReconcileHostPathProvisioner) checkSCCUsed() (bool, error) {

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -53,7 +53,6 @@ func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraintsDesire
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new SecurityContextConstraints", "SecurityContextConstraints.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 		err = r.client.Create(context.TODO(), desired)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -83,7 +82,6 @@ func (r *ReconcileHostPathProvisioner) reconcileSecurityContextConstraintsDesire
 		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating SecurityContextConstraints", "SecurityContextConstraints.Name", desired.Name)
-		recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -37,7 +37,7 @@ import (
 func (r *ReconcileHostPathProvisioner) reconcileServiceAccount(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
 	// Previous versions created resources with names that depend on the CR, whereas now, we have fixed names for those.
 	// We will remove those and have the next loop create the resources with fixed names so we don't end up with two sets of hpp resources.
-	dups, err := r.getDuplicateServiceAccount(cr.Name, namespace, cr.Spec.DisableCsi)
+	dups, err := r.getDuplicateServiceAccount(cr.Name, namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -150,7 +150,7 @@ func createServiceAccount(name, namespace string, labels map[string]string) *cor
 
 // getDuplicateServiceAccount will give us duplicate ServiceAccounts from a previous version if they exist.
 // This is possible from a previous HPP version where the resources (DaemonSet, RBAC) were named depending on the CR, whereas now, we have fixed names for those.
-func (r *ReconcileHostPathProvisioner) getDuplicateServiceAccount(customCrName, namespace string, DisableCsi bool) ([]corev1.ServiceAccount, error) {
+func (r *ReconcileHostPathProvisioner) getDuplicateServiceAccount(customCrName, namespace string) ([]corev1.ServiceAccount, error) {
 	saList := &corev1.ServiceAccountList{}
 	dups := make([]corev1.ServiceAccount, 0)
 

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -65,7 +65,6 @@ func (r *ReconcileHostPathProvisioner) reconcileServiceAccount(reqLogger logr.Lo
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
 		if err != nil && errors.IsNotFound(err) {
 			reqLogger.Info("Creating a new Service Account", "ServiceAccount.Namespace", desired.Namespace, "ServiceAccount.Name", desired.Name)
-			r.recorder.Event(cr, corev1.EventTypeNormal, createResourceStart, fmt.Sprintf(createMessageStart, desired, desired.Name))
 			err = r.client.Create(context.TODO(), desired)
 			if err != nil {
 				r.recorder.Event(cr, corev1.EventTypeWarning, createResourceFailed, fmt.Sprintf(createMessageFailed, desired.Name, err))
@@ -96,7 +95,6 @@ func (r *ReconcileHostPathProvisioner) reconcileServiceAccount(reqLogger logr.Lo
 			logJSONDiff(log, currentRuntimeObjCopy, merged)
 			// Current is different from desired, update.
 			reqLogger.Info("Updating Service Account", "ServiceAccount.Name", desired.Name)
-			r.recorder.Event(cr, corev1.EventTypeNormal, updateResourceStart, fmt.Sprintf(updateMessageStart, desired, desired.Name))
 			err = r.client.Update(context.TODO(), merged)
 			if err != nil {
 				r.recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -351,6 +351,7 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 			},
 			ResourceNames: [] string{
 				"hostpath-provisioner",
+				"hostpath-provisioner-csi",
 			},
 			Verbs: []string{
 				"delete",
@@ -403,6 +404,7 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 			},
 			ResourceNames: []string{
 				"hostpath-provisioner-admin",
+				"hostpath-provisioner-admin-csi",
 			},
 			Verbs: []string{
 				"update",
@@ -453,7 +455,9 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 				"rolebindings",
 			},
 			ResourceNames: []string{
+				"hostpath-provisioner",
 				"hostpath-provisioner-admin",
+				"hostpath-provisioner-admin-csi",
 				"hostpath-provisioner-health-check",
 			},
 			Verbs: []string{
@@ -483,7 +487,9 @@ func getOperatorRules() *[]rbacv1.PolicyRule {
 				"roles",
 			},
 			ResourceNames: []string{
+				"hostpath-provisioner",
 				"hostpath-provisioner-admin",
+				"hostpath-provisioner-admin-csi",
 				"hostpath-provisioner-health-check",
 			},
 			Verbs: []string{
@@ -548,6 +554,7 @@ func getOperatorClusterRules() *[]rbacv1.PolicyRule {
 			ResourceNames: []string{
 				"hostpath-provisioner",
 				"hostpath-provisioner-admin",
+				"hostpath-provisioner-admin-csi",
 				"hostpath-provisioner-health-check",
 			},
 			Verbs: []string{
@@ -579,6 +586,7 @@ func getOperatorClusterRules() *[]rbacv1.PolicyRule {
 			ResourceNames: []string{
 				"hostpath-provisioner",
 				"hostpath-provisioner-admin",
+				"hostpath-provisioner-admin-csi",
 				"hostpath-provisioner-health-check",
 			},
 			Verbs: []string{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

Note that this PR will cause the operator to completely ignore disableCsi, and always deploy both daemonsets. Follow up PRs will allow one to toggle either one on or off.

```release-note
NONE
```