### PR TITLE
Update tests and release scripts to use golang containers in PROW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ DOCKER_REPO?=quay.io/kubevirt
 all: test build
 
 operator:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-operator cmd/manager/main.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-operator.sh
 
 csv-generator:
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/csv-generator tools/csv-generator.go
+	GOLANG_VER=${GOLANG_VER} ./hack/build-csv-generator.sh
 
 image: operator csv-generator
 	hack/version.sh _out; \
-		docker build -t $(DOCKER_REPO)/$(IMAGE):$(TAG) -f Dockerfile .
+	docker build -t $(DOCKER_REPO)/$(IMAGE):$(TAG) -f Dockerfile .
 
 push: image
 	docker push $(DOCKER_REPO)/$(IMAGE):$(TAG)

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,7 @@ github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=

--- a/hack/build-csv-generator.sh
+++ b/hack/build-csv-generator.sh
@@ -13,17 +13,8 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
-
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
 
-# Install dependencies for the test run
-if [[ -v PROW_JOB_ID ]] ; then
-  cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner-operator
-  go get -u github.com/mgechev/revive
-  go mod vendor
-fi
-# Run test
-make test
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/csv-generator tools/csv-generator.go

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -13,17 +13,8 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
-
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 setGoInProw $GOLANG_VER
 
-# Install dependencies for the test run
-if [[ -v PROW_JOB_ID ]] ; then
-  cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner-operator
-  go get -u github.com/mgechev/revive
-  go mod vendor
-fi
-# Run test
-make test
+CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o _out/hostpath-provisioner-operator cmd/manager/main.go

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #Copyright 2021 The hostpath provisioner operator Authors.
 #
 #Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +11,12 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
-set -e
 
-script_dir="$(cd "$(dirname "$0")" && pwd -P)"
-source "${script_dir}"/common.sh
-setGoInProw $GOLANG_VER
+GOLANG_VER=${GOLANG_VER:-1.16.8}
 
-# Install dependencies for the test run
-if [[ -v PROW_JOB_ID ]] ; then
-  cd /home/prow/go/src/github.com/kubevirt/hostpath-provisioner-operator
-  go get -u github.com/mgechev/revive
-  go mod vendor
-fi
-# Run test
-make test
+function setGoInProw() {
+  if [[ -v PROW_JOB_ID ]] ; then
+    eval $(gimme ${1})
+    cp -R ~/.gimme/versions/go${1}.linux.amd64 /usr/local/go
+  fi
+}

--- a/pkg/apis/hostpathprovisioner/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/hostpathprovisioner/v1alpha1/zz_generated.openapi.go
@@ -60,17 +60,20 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_HostPathProvisioner(ref common
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.HostPathProvisionerSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.HostPathProvisionerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.HostPathProvisionerStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.HostPathProvisionerStatus"),
 						},
 					},
 				},
@@ -98,12 +101,14 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_HostPathProvisionerSpec(ref co
 					"pathConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PathConfig describes the location and layout of PV storage on nodes",
+							Default:     map[string]interface{}{},
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.PathConfig"),
 						},
 					},
 					"workload": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Restrict on which nodes HPP workload pods will be scheduled",
+							Default:     map[string]interface{}{},
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1alpha1.NodePlacement"),
 						},
 					},
@@ -135,7 +140,8 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_HostPathProvisionerStatus(ref 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/openshift/custom-resource-status/conditions/v1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/openshift/custom-resource-status/conditions/v1.Condition"),
 									},
 								},
 							},
@@ -185,8 +191,9 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_NodePlacement(ref common.Refer
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -205,7 +212,8 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_NodePlacement(ref common.Refer
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Toleration"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Toleration"),
 									},
 								},
 							},

--- a/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
@@ -60,17 +60,20 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisioner(ref common.
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.HostPathProvisionerSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.HostPathProvisionerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.HostPathProvisionerStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.HostPathProvisionerStatus"),
 						},
 					},
 				},
@@ -98,12 +101,14 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisionerSpec(ref com
 					"pathConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PathConfig describes the location and layout of PV storage on nodes",
+							Default:     map[string]interface{}{},
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.PathConfig"),
 						},
 					},
 					"workload": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Restrict on which nodes HPP workload pods will be scheduled",
+							Default:     map[string]interface{}{},
 							Ref:         ref("kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1.NodePlacement"),
 						},
 					},
@@ -142,7 +147,8 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisionerStatus(ref c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/openshift/custom-resource-status/conditions/v1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/openshift/custom-resource-status/conditions/v1.Condition"),
 									},
 								},
 							},
@@ -192,8 +198,9 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_NodePlacement(ref common.Refere
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -212,7 +219,8 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_NodePlacement(ref common.Refere
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Toleration"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Toleration"),
 									},
 								},
 							},

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -30,7 +30,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
+
 var localSchemeBuilder = runtime.SchemeBuilder{
 	hostpathprovisionerv1alpha1.AddToScheme,
 	hostpathprovisionerv1beta1.AddToScheme,

--- a/pkg/client/listers/hostpathprovisioner/v1alpha1/hostpathprovisioner.go
+++ b/pkg/client/listers/hostpathprovisioner/v1alpha1/hostpathprovisioner.go
@@ -26,10 +26,13 @@ import (
 )
 
 // HostPathProvisionerLister helps list HostPathProvisioners.
+// All objects returned here must be treated as read-only.
 type HostPathProvisionerLister interface {
 	// List lists all HostPathProvisioners in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.HostPathProvisioner, err error)
 	// Get retrieves the HostPathProvisioner from the index for a given name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.HostPathProvisioner, error)
 	HostPathProvisionerListerExpansion
 }

--- a/pkg/client/listers/hostpathprovisioner/v1beta1/hostpathprovisioner.go
+++ b/pkg/client/listers/hostpathprovisioner/v1beta1/hostpathprovisioner.go
@@ -26,10 +26,13 @@ import (
 )
 
 // HostPathProvisionerLister helps list HostPathProvisioners.
+// All objects returned here must be treated as read-only.
 type HostPathProvisionerLister interface {
 	// List lists all HostPathProvisioners in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.HostPathProvisioner, err error)
 	// Get retrieves the HostPathProvisioner from the index for a given name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1beta1.HostPathProvisioner, error)
 	HostPathProvisionerListerExpansion
 }


### PR DESCRIPTION
Instead of installing go ourselves, we can use a container that has
golang already and we can use that instead.

Signed-off-by: Alexander Wels <awels@redhat.com>

```release-note
NONE
```