### PR TITLE
Pass the tag to the version script so the operator gets the

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ csv-generator:
 	GOLANG_VER=${GOLANG_VER} ./hack/build-csv-generator.sh
 
 image: operator csv-generator
-	hack/version.sh _out; \
+	TAG=$(TAG) ./hack/version.sh ./_out; \
 	docker build -t $(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG) -f Dockerfile .
 
 push: image


### PR DESCRIPTION
Pass the tag to the version script so the operator gets the proper tag instead of v0.0.1

Signed-off-by: Alexander Wels <awels@redhat.com>

```release-note
NONE
```