### PR TITLE
Fix release script pointing to non existing script

### DIFF
--- a/hack/git-askpass.sh
+++ b/hack/git-askpass.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat "$GITHUB_TOKEN_PATH"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -53,7 +53,7 @@ function main() {
 
     export TAG
 
-    GIT_ASKPASS="$(pwd)/automation/git-askpass.sh"
+    GIT_ASKPASS="$(pwd)/hack/git-askpass.sh"
     [ -f "$GIT_ASKPASS" ] || exit 1
     export GIT_ASKPASS
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
release.sh was pointing to non existing script. This PR fixes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

