### PR TITLE
Add external snapshotter container/rbac

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -167,6 +167,39 @@ rules:
   verbs:
     - patch
 - apiGroups:
+  - "snapshot.storage.k8s.io"
+  resources:
+    - volumesnapshotclasses
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - "snapshot.storage.k8s.io"
+  resources:
+    - volumesnapshots
+  verbs:
+    - get
+- apiGroups:
+  - "snapshot.storage.k8s.io"
+  resources:
+    - volumesnapshotcontents
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - delete
+    - patch
+- apiGroups:
+  - "snapshot.storage.k8s.io"
+  resources:
+    - volumesnapshotcontents/status
+  verbs:
+    - update
+    - patch
+- apiGroups:
   - ""
   resources:
   - pods
@@ -2400,8 +2433,10 @@ spec:
               value: "k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
             - name: NODE_DRIVER_REG_IMAGE
               value: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
-            - name: LIVENESS_PROVE_IMAGE
+            - name: LIVENESS_PROBE_IMAGE
               value: "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"
+            - name: CSI_SNAPSHOT_IMAGE
+              value: "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"
             - name: CSI_SIG_STORAGE_PROVISIONER_IMAGE
               value: "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1"
             - name: VERBOSITY

--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -29,6 +29,8 @@ const (
 	CsiNodeDriverRegistrationImageDefault = "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
 	// LivenessProbeImageDefault is the default value of the liveness probe side car container image name.
 	LivenessProbeImageDefault = "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"
+	// SnapshotterImageDefault is the default value of the csi snapshotter side car container image name.
+	SnapshotterImageDefault = "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"
 	// CsiSigStorageProvisionerImageDefault is the default value of the sig storage csi provisioner side car container image name.
 	CsiSigStorageProvisionerImageDefault = "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1"
 
@@ -36,7 +38,8 @@ const (
 	csiProvisionerImageEnvVarName                  = "CSI_PROVISIONER_IMAGE"
 	externalHealthMonitorControllerImageEnvVarName = "EXTERNAL_HEALTH_MON_IMAGE"
 	nodeDriverRegistrarImageEnvVarName             = "NODE_DRIVER_REG_IMAGE"
-	livenessProbeImageEnvVarName                   = "LIVENESS_PROVE_IMAGE"
+	livenessProbeImageEnvVarName                   = "LIVENESS_PROBE_IMAGE"
+	snapshotterImageEnvVarName                     = "CSI_SNAPSHOT_IMAGE"
 	csiSigStorageProvisionerImageEnvVarName        = "CSI_SIG_STORAGE_PROVISIONER_IMAGE"
 	verbosityEnvVarName                            = "VERBOSITY"
 

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -938,6 +938,59 @@ func verifyCreateCSIClusterRole(cl client.Client) {
 				"patch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"snapshot.storage.k8s.io",
+			},
+			Resources: []string{
+				"volumesnapshotclasses",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"snapshot.storage.k8s.io",
+			},
+			Resources: []string{
+				"volumesnapshots",
+			},
+			Verbs: []string{
+				"get",
+			},
+		},
+		{
+			APIGroups: []string{
+				"snapshot.storage.k8s.io",
+			},
+			Resources: []string{
+				"volumesnapshotcontents",
+			},
+			Verbs: []string{
+				"create",
+				"get",
+				"list",
+				"watch",
+				"update",
+				"delete",
+				"patch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"snapshot.storage.k8s.io",
+			},
+			Resources: []string{
+				"volumesnapshotcontents/status",
+			},
+			Verbs: []string{
+				"update",
+				"patch",
+			},
+		},
 	}
 	Expect(crole.Rules).To(Equal(expectedRules))
 	Expect(crole.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))

--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -401,6 +401,59 @@ func createCsiClusterRoleObjectProvisioner() *rbacv1.ClusterRole {
 					"patch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"snapshot.storage.k8s.io",
+				},
+				Resources: []string{
+					"volumesnapshotclasses",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"snapshot.storage.k8s.io",
+				},
+				Resources: []string{
+					"volumesnapshots",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					"snapshot.storage.k8s.io",
+				},
+				Resources: []string{
+					"volumesnapshotcontents",
+				},
+				Verbs: []string{
+					"create",
+					"get",
+					"list",
+					"watch",
+					"update",
+					"delete",
+					"patch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"snapshot.storage.k8s.io",
+				},
+				Resources: []string{
+					"volumesnapshotcontents/status",
+				},
+				Verbs: []string{
+					"update",
+					"patch",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added external snapshotter sidecar and rbac to operator, this is needed to support snapshotting capability in the hostpath csi driver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added snapshotting sidecar and RBAC to daemonset.
```

