### PR TITLE
Enable leader election for csi-provisioner and snapshotter

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -180,7 +180,7 @@ func getDaemonSetArgs(reqLogger logr.Logger, namespace string, legacyProvisioner
 		res.snapshotterImage = os.Getenv(snapshotterImageEnvVarName)
 		if res.snapshotterImage == "" {
 			reqLogger.V(3).Info(fmt.Sprintf("%s not set, defaulting to %s", snapshotterImageEnvVarName, SnapshotterImageDefault))
-			res.livenessProbeImage = LivenessProbeImageDefault
+			res.snapshotterImage = SnapshotterImageDefault
 		}
 
 		res.csiProvisionerImage = os.Getenv(csiSigStorageProvisionerImageEnvVarName)
@@ -535,6 +535,7 @@ func createCSIDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, req
 							Args: []string{
 								fmt.Sprintf("--v=%d", args.verbosity),
 								fmt.Sprintf("--csi-address=%s", csiSocket),
+								"--leader-election",
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.BoolPtr(true),
@@ -557,6 +558,7 @@ func createCSIDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, req
 								"--immediate-topology=false",
 								"--strict-topology=true",
 								"--node-deployment=true",
+								"--leader-election",
 							},
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Without leader election we can have multiples trying to handle requests and unexpected results can happen. Also fixed default not being set properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: csi-provisioner and snapshotter were not using leader election.
```

