### PR TITLE
Switch listType to atomic

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1358,7 +1358,7 @@ spec:
                   - type
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
               observedVersion:
                 description: ObservedVersion The observed version of the HostPathProvisioner
                   deployment
@@ -2377,7 +2377,7 @@ spec:
                   - type
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
               observedVersion:
                 description: ObservedVersion The observed version of the HostPathProvisioner
                   deployment

--- a/pkg/apis/hostpathprovisioner/v1alpha1/hostpathprovisioner_types.go
+++ b/pkg/apis/hostpathprovisioner/v1alpha1/hostpathprovisioner_types.go
@@ -37,7 +37,7 @@ type HostPathProvisionerSpec struct {
 // +k8s:openapi-gen=true
 type HostPathProvisionerStatus struct {
 	// Conditions contains the current conditions observed by the operator
-	// +listType=set
+	// +listType=atomic
 	Conditions []conditions.Condition `json:"conditions,omitempty" optional:"true"`
 	// OperatorVersion The version of the HostPathProvisioner Operator
 	OperatorVersion string `json:"operatorVersion,omitempty" optional:"true"`

--- a/pkg/apis/hostpathprovisioner/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/hostpathprovisioner/v1alpha1/zz_generated.openapi.go
@@ -131,7 +131,7 @@ func schema_pkg_apis_hostpathprovisioner_v1alpha1_HostPathProvisionerStatus(ref 
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_types.go
@@ -39,7 +39,7 @@ type HostPathProvisionerSpec struct {
 // +k8s:openapi-gen=true
 type HostPathProvisionerStatus struct {
 	// Conditions contains the current conditions observed by the operator
-	// +listType=set
+	// +listType=atomic
 	Conditions []conditions.Condition `json:"conditions,omitempty" optional:"true"`
 	// OperatorVersion The version of the HostPathProvisioner Operator
 	OperatorVersion string `json:"operatorVersion,omitempty" optional:"true"`

--- a/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/zz_generated.openapi.go
@@ -146,7 +146,7 @@ func schema_pkg_apis_hostpathprovisioner_v1beta1_HostPathProvisionerStatus(ref c
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
listType=set is not supported if the elements of the list are either object or array https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/validation/validation.go#L851-L863 switching to atomic, since the hpp operator will modify all the conditions at once.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

