### PR TITLE
Generate operator deployment in csv-generator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2436,6 +2436,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: INSTALLER_PART_OF_LABEL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/part-of']
+            - name: INSTALLER_VERSION_LABEL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
             - name: OPERATOR_NAME
               value: "hostpath-provisioner-operator"
             - name: PROVISIONER_IMAGE

--- a/tools/helper/crd_generated.go
+++ b/tools/helper/crd_generated.go
@@ -1015,7 +1015,7 @@ spec:
                   - type
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
               observedVersion:
                 description: ObservedVersion The observed version of the HostPathProvisioner
                   deployment
@@ -2034,7 +2034,7 @@ spec:
                   - type
                   type: object
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
               observedVersion:
                 description: ObservedVersion The observed version of the HostPathProvisioner
                   deployment

--- a/tools/helper/operator_deployment_generated.go
+++ b/tools/helper/operator_deployment_generated.go
@@ -1,0 +1,69 @@
+package helper
+
+//HppOperatorDeployment is a string yaml of the hpp operator deployment
+var HppOperatorDeployment string = 
+`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hostpath-provisioner-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: hostpath-provisioner-operator
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: hostpath-provisioner-operator
+    spec:
+      containers:
+      - command:
+        - hostpath-provisioner-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: INSTALLER_PART_OF_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/part-of']
+        - name: INSTALLER_VERSION_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        - name: OPERATOR_NAME
+          value: hostpath-provisioner-operator
+        - name: PROVISIONER_IMAGE
+          value: quay.io/kubevirt/hostpath-provisioner:latest
+        - name: CSI_PROVISIONER_IMAGE
+          value: quay.io/kubevirt/hostpath-csi-driver:latest
+        - name: EXTERNAL_HEALTH_MON_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
+        - name: NODE_DRIVER_REG_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+        - name: LIVENESS_PROBE_IMAGE
+          value: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+        - name: CSI_SNAPSHOT_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
+        - name: CSI_SIG_STORAGE_PROVISIONER_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
+        - name: VERBOSITY
+          value: "3"
+        image: quay.io/kubevirt/hostpath-provisioner-operator:latest
+        imagePullPolicy: Always
+        name: hostpath-provisioner-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 150Mi
+      serviceAccountName: hostpath-provisioner-operator
+status: {}
+`


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The csv generator was updated to pull generated output from operator.yaml, except for the operator deployment which is important for the csi driver to work with the HCO
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

