### PR TITLE
Drop crd-generator from csv-generator target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: test build
 operator:
 	GOLANG_VER=${GOLANG_VER} ./hack/build-operator.sh
 
-csv-generator: crd-generator
+csv-generator:
 	GOLANG_VER=${GOLANG_VER} ./hack/build-csv-generator.sh
 
 crd-generator: generate-crd


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We see an error in generate-crds on downstream pipelines related to `go get`ting,
but in fact we don't have to since the updated CRD is already there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

