### PR TITLE
Replace the priorityClass to kubevirt-cluster-critical

### DIFF
--- a/tools/helper/helper.go
+++ b/tools/helper/helper.go
@@ -41,7 +41,7 @@ type OperatorArgs struct {
 }
 
 const (
-	openshiftPriorityClassName = "openshift-user-critical"
+	kubevirtPriorityClassName = "kubevirt-cluster-critical"
 )
 
 func CreateOperatorDeployment(args *OperatorArgs) *appsv1.Deployment {
@@ -50,12 +50,12 @@ func CreateOperatorDeployment(args *OperatorArgs) *appsv1.Deployment {
 	deployment.SetNamespace(args.Namespace)
 	deployment.Spec.Selector.MatchLabels["operator.hostpath-provisioner.kubevirt.io"] = ""
 	deployment.Spec.Template.Labels["operator.hostpath-provisioner.kubevirt.io"] = ""
-	deployment.Spec.Template.Spec.PriorityClassName = "openshift-user-critical"
+	deployment.Spec.Template.Spec.PriorityClassName = kubevirtPriorityClassName
 	deployment.Spec.Template.Spec.Containers[0].Image = args.OperatorImage
 	deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(args.ImagePullPolicy)
 	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "PRIORITY_CLASS",
-		Value: openshiftPriorityClassName,
+		Value: kubevirtPriorityClassName,
 	})
 	setEnvVariable("VERBOSITY", args.Verbosity, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("PROVISIONER_IMAGE", args.ProvisionerImage, deployment.Spec.Template.Spec.Containers[0].Env)


### PR DESCRIPTION
The current priority class for the operator is openshift-user-critical. This priority class does not exist in Kubernetes.

Instead, use the kubevirt-cluster-critical priority class that is created by HCO.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #158

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace the priorityClass to kubevirt-cluster-critical
```

