### PR TITLE
Fix how we reconcile the prometheus resources to avoid spam

### DIFF
--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -87,13 +87,24 @@ func (r *ReconcileHostPathProvisioner) reconcilePrometheusRuleDesired(reqLogger 
 		return reconcile.Result{}, err
 	}
 
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged PrometheusRule from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// PrometheusRule already exists, check if we need to update.
-	if !reflect.DeepEqual(found.Spec, desired.Spec) {
-		logJSONDiff(reqLogger, found, desired)
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating PrometheusRule", "PrometheusRule.Name", desired.Name)
-		found.Spec = desired.Spec
-		err = r.client.Update(context.TODO(), found)
+		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
 			return reconcile.Result{}, err
@@ -127,13 +138,24 @@ func (r *ReconcileHostPathProvisioner) reconcilePrometheusRoleDesired(reqLogger 
 		return reconcile.Result{}, err
 	}
 
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged Role from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Prometheus Role already exists, check if we need to update.
-	if !reflect.DeepEqual(found.Rules, desired.Rules) {
-		logJSONDiff(reqLogger, found, desired)
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating Prometheus Role", "Role.Name", desired.Name)
-		found.Rules = desired.Rules
-		err = r.client.Update(context.TODO(), found)
+		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
 			return reconcile.Result{}, err
@@ -167,13 +189,24 @@ func (r *ReconcileHostPathProvisioner) reconcilePrometheusRoleBindingDesired(req
 		return reconcile.Result{}, err
 	}
 
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged RoleBinding from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Prometheus RoleBinding already exists, check if we need to update.
-	if !reflect.DeepEqual(found.Subjects, desired.Subjects) {
-		logJSONDiff(reqLogger, found, desired)
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating Prometheus RoleBinding", "RoleBinding.Name", desired.Name)
-		found.Subjects = desired.Subjects
-		err = r.client.Update(context.TODO(), found)
+		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
 			return reconcile.Result{}, err
@@ -207,13 +240,24 @@ func (r *ReconcileHostPathProvisioner) reconcilePrometheusServiceMonitorDesired(
 		return reconcile.Result{}, err
 	}
 
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged ServiceMonitor from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// ServiceMonitor already exists, check if we need to update.
-	if !reflect.DeepEqual(found.Spec, desired.Spec) {
-		logJSONDiff(reqLogger, found, desired)
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating Prometheus ServiceMonitor", "ServiceMonitor.Name", desired.Name)
-		found.Spec = desired.Spec
-		err = r.client.Update(context.TODO(), found)
+		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
 			return reconcile.Result{}, err
@@ -247,13 +291,24 @@ func (r *ReconcileHostPathProvisioner) reconcilePrometheusServiceDesired(reqLogg
 		return reconcile.Result{}, err
 	}
 
+	// Keep a copy of the original for comparison later.
+	currentRuntimeObjCopy := found.DeepCopyObject()
+
+	// allow users to add new annotations (but not change ours)
+	mergeLabelsAndAnnotations(desired, found)
+
+	// create merged Service from found and desired.
+	merged, err := mergeObject(desired, found)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Service already exists, check if we need to update.
-	if !reflect.DeepEqual(found.Spec, desired.Spec) {
-		logJSONDiff(reqLogger, found, desired)
+	if !reflect.DeepEqual(currentRuntimeObjCopy, merged) {
+		logJSONDiff(reqLogger, currentRuntimeObjCopy, merged)
 		// Current is different from desired, update.
 		reqLogger.Info("Updating Prometheus Service", "Service.Name", desired.Name)
-		found.Spec = desired.Spec
-		err = r.client.Update(context.TODO(), found)
+		err = r.client.Update(context.TODO(), merged)
 		if err != nil {
 			recorder.Event(cr, corev1.EventTypeWarning, updateResourceFailed, fmt.Sprintf(updateMessageFailed, desired.Name, err))
 			return reconcile.Result{}, err


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Avoids this spam in operator log:
```bash
{"level":"info","ts":1636476553.5133832,"logger":"controller_hostpathprovisioner","msg":"DIFF","Request.Namespace":"","Request.Name":"hostpath-provisioner","obj":{"apiVersion":"v1","kind":"Service","namespace":"hostpath-provisioner","name":"hpp-prometheus-metrics"},"patch":"[{\"op\":\"replace\",\"path\":\"/metadata/creationTimestamp\",\"value\":null},{\"op\":\"remove\",\"path\":\"/metadata/resourceVersion\"},{\"op\":\"remove\",\"path\":\"/metadata/managedFields\"},{\"op\":\"remove\",\"path\":\"/metadata/uid\"},{\"op\":\"remove\",\"path\":\"/spec/sessionAffinity\"},{\"op\":\"remove\",\"path\":\"/spec/ipFamilyPolicy\"},{\"op\":\"remove\",\"path\":\"/spec/internalTrafficPolicy\"},{\"op\":\"remove\",\"path\":\"/spec/clusterIP\"},{\"op\":\"remove\",\"path\":\"/spec/type\"},{\"op\":\"remove\",\"path\":\"/spec/clusterIPs\"},{\"op\":\"remove\",\"path\":\"/spec/ipFamilies\"},{\"op\":\"remove\",\"path\":\"/kind\"},{\"op\":\"remove\",\"path\":\"/apiVersion\"}]"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

