### PR TITLE
Change how leader election works in combination with ready probe

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -31,7 +30,6 @@ import (
 	"kubevirt.io/hostpath-provisioner-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -87,14 +85,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.TODO()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "hostpath-provisioner-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:              namespace,
@@ -102,6 +92,8 @@ func main() {
 		HealthProbeBindAddress: "0.0.0.0:6060",
 		ReadinessEndpointName:  "/readyz",
 		LivenessEndpointName:   "/livez",
+		LeaderElection:         true,
+		LeaderElectionID:       "hostpath-provisioner-operator-lock",
 	})
 	if err != nil {
 		log.Error(err, "")
@@ -145,7 +137,6 @@ func main() {
 	}
 
 	log.Info("Starting the Cmd.")
-
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Error(err, "Manager exited non-zero")


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On upgrades the leader election would check before starting the ready probe this would make the leader election fail because the original pod wasn't deleted because the ready probe on the new operator would fail, since it was waiting on the leader election.

Passed the leader election setup directly into the manager, which knows how to orchestrate this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

