### PR TITLE
[release-v0.10] Manual cherrypick of #170

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -296,7 +296,7 @@ func (r *ReconcileHostPathProvisioner) Reconcile(context context.Context, reques
 		MarkCrFailedHealing(cr, reconcileFailed, fmt.Sprintf("Unable to successfully reconcile: %v", err))
 		r.recorder.Event(cr, corev1.EventTypeWarning, reconcileFailed, fmt.Sprintf("Unable to successfully reconcile: %v", err))
 	}
-	return res, nil
+	return res, err
 }
 
 func (r *ReconcileHostPathProvisioner) deleteAllRbac(reqLogger logr.Logger, namespace string) (reconcile.Result, error) {

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -677,6 +677,52 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(ds.Spec.Template.Spec.NodeSelector).To(BeEmpty())
 		Expect(ds.Spec.Template.Spec.Tolerations).To(BeEmpty())
 	})
+
+	It("Should delete daemonsets from versions with junk in .spec.selector", func() {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}
+		dsNN := types.NamespacedName{
+			Name:      MultiPurposeHostPathProvisionerName,
+			Namespace: "test-namespace",
+		}
+		cr, r, cl = createDeployedCr(cr)
+		// Now modify the daemonSet to something not desired.
+		ds := &appsv1.DaemonSet{}
+		err := cl.Get(context.TODO(), dsNN, ds)
+		Expect(err).NotTo(HaveOccurred())
+		ds.Spec.Selector.MatchLabels = map[string]string{
+			"k8s-app": MultiPurposeHostPathProvisionerName,
+			"not":     "desired",
+		}
+		err = cl.Update(context.TODO(), ds)
+		Expect(err).NotTo(HaveOccurred())
+		ds = &appsv1.DaemonSet{}
+		err = cl.Get(context.TODO(), dsNN, ds)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Spec.Selector.MatchLabels).To(Equal(
+			map[string]string{
+				"k8s-app": MultiPurposeHostPathProvisionerName,
+				"not":     "desired",
+			},
+		))
+
+		// Run the reconcile loop
+		_, err = r.Reconcile(context.TODO(), req)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("DaemonSet with extra selector labels spotted, cleaning up and requeueing"))
+		// Artificial requeue (err occured implies requeue)
+		_, err = r.Reconcile(context.TODO(), req)
+		Expect(err).ToNot(HaveOccurred())
+		// Check the daemonSet value, make sure it changed back.
+		ds = &appsv1.DaemonSet{}
+		err = cl.Get(context.TODO(), dsNN, ds)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Spec.Selector.MatchLabels).To(Equal(selectorLabels))
+	})
 })
 
 // After this has run, the returned cr state should be available, not progressing and not degraded.
@@ -788,6 +834,12 @@ func verifyCreateDaemonSet(cl client.Client) {
 	// Check k8s recommended labels
 	Expect(ds.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 	Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(ProvisionerImageDefault))
+	// No junk in .spec.selector, should only be a minimal set that is needed to know which pods are under our governance
+	Expect(ds.Spec.Selector.MatchLabels).To(Equal(
+		map[string]string{
+			"k8s-app": MultiPurposeHostPathProvisionerName,
+		},
+	))
 	// Check use naming prefix
 	Expect(ds.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("false"))
 	// Check directory
@@ -808,6 +860,12 @@ func verifyCreateDaemonSetCsi(cl client.Client) {
 	// Check k8s recommended labels
 	Expect(ds.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 	Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(CsiProvisionerImageDefault))
+	// No junk in .spec.selector, should only be a minimal set that is needed to know which pods are under our governance
+	Expect(ds.Spec.Selector.MatchLabels).To(Equal(
+		map[string]string{
+			"k8s-app": MultiPurposeHostPathProvisionerName,
+		},
+	))
 }
 
 func verifyCreateServiceAccount(cl client.Client) {

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -46,6 +46,9 @@ const (
 var (
 	socketDirVolumeMount = corev1.VolumeMount{Name: "socket-dir", MountPath: "/csi"}
 	dataDirVolumeMount   = corev1.VolumeMount{Name: "csi-data-dir", MountPath: "/csi-data-dir"}
+	selectorLabels       = map[string]string{
+		"k8s-app": MultiPurposeHostPathProvisionerName,
+	}
 )
 
 type daemonSetArgs struct {
@@ -110,6 +113,15 @@ func (r *ReconcileHostPathProvisioner) reconcileDaemonSetForSa(reqLogger logr.Lo
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, err
+	}
+
+	// Cleanup daemonsets from previous versions where .spec.selector contains junk
+	// We will remove those and have the next loop create them
+	if !reflect.DeepEqual(found.Spec.Selector.MatchLabels, desired.Spec.Selector.MatchLabels) {
+		if err := r.deleteDaemonSet(desired.Name, desired.Namespace); err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, fmt.Errorf("DaemonSet with extra selector labels spotted, cleaning up and requeueing")
 	}
 
 	// Keep a copy of the original for comparison later.
@@ -241,7 +253,7 @@ func createDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, reqLog
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selectorLabels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -354,7 +366,7 @@ func createCSIDaemonSetObject(cr *hostpathprovisionerv1.HostPathProvisioner, req
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selectorLabels,
 			},
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Relationship labels have slipped in to our immutable .spec.selector section
of the daemonset, which is problematic on upgrade;
- We're trying to update the pod's label values (version=newVersion)
- We get ```selector does not match template labels```, which is true because the selector will always have the old values (immutable)

.spec.selector is a minimal set that is needed to know which pods are under our governance, and is immutable,
and hence we should not have relationship labels there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2022895

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cant reconcile DaemonSet on upgrade because selector & labels mismatch
```

