### PR TITLE
[release-v0.9] Manual cherrypick of #170

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -306,7 +306,7 @@ func (r *ReconcileHostPathProvisioner) Reconcile(request reconcile.Request) (rec
 		MarkCrFailedHealing(cr, reconcileFailed, fmt.Sprintf("Unable to successfully reconcile: %v", err))
 		r.recorder.Event(cr, corev1.EventTypeWarning, reconcileFailed, fmt.Sprintf("Unable to successfully reconcile: %v", err))
 	}
-	return res, nil
+	return res, err
 }
 
 func canUpgrade(current, target string) (bool, error) {


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Relationship labels have slipped in to our immutable .spec.selector section
of the daemonset, which is problematic on upgrade;
- We're trying to update the pod's label values (version=newVersion)
- We get ```selector does not match template labels```, which is true because the selector will always have the old values (immutable)

.spec.selector is a minimal set that is needed to know which pods are under our governance, and is immutable,
and hence we should not have relationship labels there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2022895

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cant reconcile DaemonSet on upgrade because selector & labels mismatch
```

