### PR TITLE
Add common labels into alert definitions

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -1146,7 +1146,9 @@ func verifyCreatePrometheusResources(cl client.Client) {
 			"runbook_url": runbookURLBasePath + "HPPOperatorDown",
 		},
 		Labels: map[string]string{
-			"severity": "warning",
+			"severity":                      "warning",
+			"kubernetes_operator_part_of":   "kubevirt",
+			"kubernetes_operator_component": "hostpath-provisioner-operator",
 		},
 	}
 	Expect(rule.Spec.Groups[0].Rules).To(ContainElement(hppDownAlert))

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -38,11 +38,16 @@ import (
 )
 
 const (
-	ruleName            = "prometheus-hpp-rules"
-	rbacName            = "hostpath-provisioner-monitoring"
-	monitorName         = "service-monitor-hpp"
-	defaultMonitoringNs = "monitoring"
-	runbookURLBasePath  = "https://kubevirt.io/monitoring/runbooks/"
+	ruleName                 = "prometheus-hpp-rules"
+	rbacName                 = "hostpath-provisioner-monitoring"
+	monitorName              = "service-monitor-hpp"
+	defaultMonitoringNs      = "monitoring"
+	runbookURLBasePath       = "https://kubevirt.io/monitoring/runbooks/"
+	severityAlertLabelKey    = "severity"
+	partOfAlertLabelKey      = "kubernetes_operator_part_of"
+	partOfAlertLabelValue    = "kubevirt"
+	componentAlertLabelKey   = "kubernetes_operator_component"
+	componentAlertLabelValue = "hostpath-provisioner-operator"
 )
 
 func (r *ReconcileHostPathProvisioner) reconcilePrometheusInfra(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string, recorder record.EventRecorder) (reconcile.Result, error) {
@@ -411,7 +416,9 @@ func createPrometheusRule(cr *hostpathprovisionerv1.HostPathProvisioner, namespa
 								"runbook_url": runbookURLBasePath + "HPPOperatorDown",
 							},
 							map[string]string{
-								"severity": "warning",
+								severityAlertLabelKey:  "warning",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 						generateAlertRule(
@@ -423,7 +430,9 @@ func createPrometheusRule(cr *hostpathprovisionerv1.HostPathProvisioner, namespa
 								"runbook_url": runbookURLBasePath + "HPPNotReady",
 							},
 							map[string]string{
-								"severity": "warning",
+								severityAlertLabelKey:  "warning",
+								partOfAlertLabelKey:    partOfAlertLabelValue,
+								componentAlertLabelKey: componentAlertLabelValue,
 							},
 						),
 					},


### PR DESCRIPTION
We want to be able to list all kubevirt alerts so we added labels to
differentiate them.

Signed-off-by: assafad <aadmi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added common labels into alert definitions
```

