### PR TITLE
Only start legacy provisioner on legacy CR

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset_test.go
+++ b/pkg/controller/hostpathprovisioner/daemonset_test.go
@@ -120,14 +120,14 @@ var _ = Describe("Controller reconcile loop", func() {
 			Expect(foundVolume).To(BeTrue(), "did not find expected volume path /tmp/test")
 		})
 
-		table.DescribeTable("Should fix a changed legacy daemonSet", func(cr *hppv1.HostPathProvisioner) {
+		It("Should fix a changed legacy daemonSet", func() {
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "test-name",
 					Namespace: testNamespace,
 				},
 			}
-			cr, r, cl = createDeployedCr(cr)
+			_, r, cl = createDeployedCr(createLegacyCr())
 			// Now modify the daemonSet to something not desired.
 			ds := &appsv1.DaemonSet{
 				ObjectMeta: v1.ObjectMeta{
@@ -155,11 +155,7 @@ var _ = Describe("Controller reconcile loop", func() {
 			err = cl.Get(context.TODO(), dsNN, ds)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.Spec.Template.Spec.Volumes[0].Name).To(Equal(legacyVolume))
-		},
-			table.Entry("legacyCr", createLegacyCr()),
-			table.Entry("legacyStoragePoolCr", createLegacyStoragePoolCr()),
-			table.Entry("storagePoolCr", createStoragePoolWithTemplateCr()),
-		)
+		})
 
 		table.DescribeTable("Should fix a changed csi daemonSet", func(cr *hppv1.HostPathProvisioner) {
 			req := reconcile.Request{

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -50,7 +50,13 @@ func (r *ReconcileHostPathProvisioner) reconcileServiceAccount(reqLogger logr.Lo
 	}
 
 	accounts := make([]*corev1.ServiceAccount, 0)
-	accounts = append(accounts, createServiceAccountObject(namespace))
+	if r.isLegacy(cr) {
+		accounts = append(accounts, createServiceAccountObject(namespace))
+	} else {
+		if err := r.deleteServiceAccount(ProvisionerServiceAccountName, namespace); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 	accounts = append(accounts, createCsiServiceAccountObject(namespace))
 	for _, desired := range accounts {
 		// Define a new Service Account object


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Also refactor some of the reconcile code to use common pattern and reduce code copy and paste.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Only start legacy provisioner if legacy CR is provided.
```

