### PR TITLE
Fix bug where the legacy storage pool kept being added to the status.

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -588,7 +588,7 @@ func checkApplicationAvailable(daemonSet *appsv1.DaemonSet) bool {
 
 func (r *ReconcileHostPathProvisioner) addFinalizer(reqLogger logr.Logger, obj client.Object) error {
 	if obj.GetDeletionTimestamp() == nil {
-		reqLogger.Info("Adding deletion Finalizer")
+		reqLogger.V(3).Info("Adding deletion Finalizer")
 		AddFinalizer(obj, hppFinalizer)
 
 		// Update CR

--- a/pkg/controller/hostpathprovisioner/storagepool.go
+++ b/pkg/controller/hostpathprovisioner/storagepool.go
@@ -527,13 +527,13 @@ func (r *ReconcileHostPathProvisioner) getClaimStatusesByStoragePool(storagePool
 
 func (r *ReconcileHostPathProvisioner) reconcileStoragePoolStatus(logger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) error {
 	// Check the template of the storage pool
+	newStoragePoolStatuses := make([]hostpathprovisionerv1.StoragePoolStatus, 0)
 	if cr.Spec.PathConfig != nil {
-		cr.Status.StoragePoolStatuses = append(cr.Status.StoragePoolStatuses, hostpathprovisionerv1.StoragePoolStatus{
+		newStoragePoolStatuses = append(newStoragePoolStatuses, hostpathprovisionerv1.StoragePoolStatus{
 			Name:  legacyStoragePoolName,
 			Phase: hostpathprovisionerv1.StoragePoolReady,
 		})
 	} else {
-		newStoragePoolStatuses := make([]hostpathprovisionerv1.StoragePoolStatus, 0)
 		for _, storagePool := range cr.Spec.StoragePools {
 			if storagePool.PVCTemplate != nil {
 				deployments, err := r.storagePoolDeploymentsByStoragePool(cr, namespace, &storagePool)
@@ -567,8 +567,8 @@ func (r *ReconcileHostPathProvisioner) reconcileStoragePoolStatus(logger logr.Lo
 				})
 			}
 		}
-		cr.Status.StoragePoolStatuses = newStoragePoolStatuses
 	}
+	cr.Status.StoragePoolStatuses = newStoragePoolStatuses
 	return nil
 }
 

--- a/pkg/controller/hostpathprovisioner/storagepool_test.go
+++ b/pkg/controller/hostpathprovisioner/storagepool_test.go
@@ -147,6 +147,26 @@ var _ = Describe("Controller reconcile loop", func() {
 			Expect(len(jobList.Items)).To(Equal(1))
 			Expect(jobList.Items[0].GetName()).To(Equal("cleanup-pool-local-node1"))
 		})
+
+		It("Status length should remain at one with legacy CR", func() {
+			cr, r, cl := createDeployedCr(createLegacyCr())
+			err := cl.Get(context.TODO(), client.ObjectKeyFromObject(cr), cr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(cr.Status.StoragePoolStatuses)).To(Equal(1))
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-name",
+					Namespace: testNamespace,
+				},
+			}
+			for i := 0; i < 10; i++ {
+				_, err := r.Reconcile(context.TODO(), req)
+				Expect(err).ToNot(HaveOccurred())
+				err = cl.Get(context.TODO(), client.ObjectKeyFromObject(cr), cr)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			Expect(len(cr.Status.StoragePoolStatuses)).To(Equal(1))
+		})
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Legacy CR would cause the storage pool status to be append constantly instead of replaced.
```

