### PR TITLE
Fix bug where path was not being created if it didn't exist on the host already.

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -440,7 +440,7 @@ func buildPathArgFromStoragePoolInfo(storagePools []StoragePoolInfo) string {
 }
 
 func buildVolumesFromStoragePoolInfo(storagePools []StoragePoolInfo) []corev1.Volume {
-	directory := corev1.HostPathDirectory
+	directoryOrCreate := corev1.HostPathDirectoryOrCreate
 	volumes := make([]corev1.Volume, 0)
 	for _, storagePool := range storagePools {
 		volumes = append(volumes, corev1.Volume{
@@ -448,7 +448,7 @@ func buildVolumesFromStoragePoolInfo(storagePools []StoragePoolInfo) []corev1.Vo
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: storagePool.Path,
-					Type: &directory,
+					Type: &directoryOrCreate,
 				},
 			},
 		})


### PR DESCRIPTION

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the path didn't exist on the host, the pod would not get created because the path wasn't there. Switched to directoryOrCreate which will create the directory if it doesn't exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

