### PR TITLE
Stop deploy the csi external health monitor

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -43,7 +43,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   verbs:
   - update
   - delete
@@ -73,7 +72,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   verbs:
   - update
   - delete
@@ -355,7 +353,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   - hostpath-provisioner-monitoring
   verbs:
   - update
@@ -368,7 +365,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   - hostpath-provisioner-monitoring
   verbs:
   - update
@@ -2787,8 +2783,6 @@ spec:
               value: "quay.io/kubevirt/hostpath-provisioner:latest"
             - name: CSI_PROVISIONER_IMAGE
               value: "quay.io/kubevirt/hostpath-csi-driver:latest"
-            - name: EXTERNAL_HEALTH_MON_IMAGE
-              value: "k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
             - name: NODE_DRIVER_REG_IMAGE
               value: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
             - name: LIVENESS_PROBE_IMAGE

--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -23,8 +23,6 @@ const (
 	ProvisionerImageDefault = "hostpath-provisioner"
 	// CsiProvisionerImageDefault is the default value of the hostpath provisioner csi container image name.
 	CsiProvisionerImageDefault = "hostpath-provisioner-csi"
-	// CsiExternalHealthMonitorControllerImageDefault is the default value of the sig storage csi health monitor controller side car container image name.
-	CsiExternalHealthMonitorControllerImageDefault = "k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0"
 	// CsiNodeDriverRegistrationImageDefault is the default value of the sig storage csi node registration side car container image name.
 	CsiNodeDriverRegistrationImageDefault = "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
 	// LivenessProbeImageDefault is the default value of the liveness probe side car container image name.
@@ -34,15 +32,14 @@ const (
 	// CsiSigStorageProvisionerImageDefault is the default value of the sig storage csi provisioner side car container image name.
 	CsiSigStorageProvisionerImageDefault = "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1"
 
-	operatorImageEnvVarName                        = "OPERATOR_IMAGE"
-	provisionerImageEnvVarName                     = "PROVISIONER_IMAGE"
-	csiProvisionerImageEnvVarName                  = "CSI_PROVISIONER_IMAGE"
-	externalHealthMonitorControllerImageEnvVarName = "EXTERNAL_HEALTH_MON_IMAGE"
-	nodeDriverRegistrarImageEnvVarName             = "NODE_DRIVER_REG_IMAGE"
-	livenessProbeImageEnvVarName                   = "LIVENESS_PROBE_IMAGE"
-	snapshotterImageEnvVarName                     = "CSI_SNAPSHOT_IMAGE"
-	csiSigStorageProvisionerImageEnvVarName        = "CSI_SIG_STORAGE_PROVISIONER_IMAGE"
-	verbosityEnvVarName                            = "VERBOSITY"
+	operatorImageEnvVarName                 = "OPERATOR_IMAGE"
+	provisionerImageEnvVarName              = "PROVISIONER_IMAGE"
+	csiProvisionerImageEnvVarName           = "CSI_PROVISIONER_IMAGE"
+	nodeDriverRegistrarImageEnvVarName      = "NODE_DRIVER_REG_IMAGE"
+	livenessProbeImageEnvVarName            = "LIVENESS_PROBE_IMAGE"
+	snapshotterImageEnvVarName              = "CSI_SNAPSHOT_IMAGE"
+	csiSigStorageProvisionerImageEnvVarName = "CSI_SIG_STORAGE_PROVISIONER_IMAGE"
+	verbosityEnvVarName                     = "VERBOSITY"
 
 	// OperatorServiceAccountName is the name of Service Account used to run the operator.
 	OperatorServiceAccountName = "hostpath-provisioner-operator"
@@ -51,7 +48,6 @@ const (
 	// ProvisionerServiceAccountNameCsi is the name of Service Account used to run the csi driver.
 	ProvisionerServiceAccountNameCsi = "hostpath-provisioner-admin-csi"
 
-	healthCheckName = "hostpath-provisioner-health-check"
 	// MultiPurposeHostPathProvisionerName is the name used for the DaemonSet, ClusterRole/Binding, SCC and k8s-app label value.
 	MultiPurposeHostPathProvisionerName = "hostpath-provisioner"
 	// PartOfLabelEnvVarName is the environment variable name for the part-of label value

--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -430,7 +430,7 @@ func (r *ReconcileHostPathProvisioner) reconcileStatus(context context.Context, 
 }
 
 func (r *ReconcileHostPathProvisioner) deleteAllRbac(reqLogger logr.Logger, namespace string) (reconcile.Result, error) {
-	for _, name := range []string{ProvisionerServiceAccountName, ProvisionerServiceAccountNameCsi, healthCheckName, MultiPurposeHostPathProvisionerName} {
+	for _, name := range []string{ProvisionerServiceAccountName, ProvisionerServiceAccountNameCsi, MultiPurposeHostPathProvisionerName} {
 		reqLogger.Info("Deleting ClusterRoleBinding", "ClusterRoleBinding", name)
 		if err := r.deleteClusterRoleBindingObject(name); err != nil {
 			reqLogger.Error(err, "Unable to delete ClusterRoleBinding")

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Controller reconcile loop", func() {
 		for _, container := range ds.Spec.Template.Spec.Containers {
 			sidecarImages = append(sidecarImages, container.Image)
 		}
-		Expect(sidecarImages).To(ContainElements(CsiProvisionerImageDefault, CsiExternalHealthMonitorControllerImageDefault, CsiNodeDriverRegistrationImageDefault, LivenessProbeImageDefault, CsiSigStorageProvisionerImageDefault))
+		Expect(sidecarImages).To(ContainElements(CsiProvisionerImageDefault, CsiNodeDriverRegistrationImageDefault, LivenessProbeImageDefault, CsiSigStorageProvisionerImageDefault))
 		// Ensure the snapshot sidecar is not there.
 		Expect(sidecarImages).ToNot(ContainElement(SnapshotterImageDefault))
 		found := false
@@ -135,7 +135,7 @@ var _ = Describe("Controller reconcile loop", func() {
 		for _, container := range ds.Spec.Template.Spec.Containers {
 			sidecarImages = append(sidecarImages, container.Image)
 		}
-		Expect(sidecarImages).To(ContainElements(CsiProvisionerImageDefault, CsiExternalHealthMonitorControllerImageDefault, CsiNodeDriverRegistrationImageDefault, LivenessProbeImageDefault, CsiSigStorageProvisionerImageDefault, SnapshotterImageDefault))
+		Expect(sidecarImages).To(ContainElements(CsiProvisionerImageDefault, CsiNodeDriverRegistrationImageDefault, LivenessProbeImageDefault, CsiSigStorageProvisionerImageDefault, SnapshotterImageDefault))
 		found = false
 		for _, volume := range ds.Spec.Template.Spec.Volumes {
 			if volume.Name == csiVolume {
@@ -806,84 +806,6 @@ func verifyCreateCSIClusterRole(cl client.Client, enableSnapshot bool) {
 
 	Expect(crole.Rules).To(Equal(expectedRules))
 	Expect(crole.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
-
-	crole = &rbacv1.ClusterRole{}
-	nn = types.NamespacedName{
-		Name: healthCheckName,
-	}
-	err = cl.Get(context.TODO(), nn, crole)
-	Expect(err).NotTo(HaveOccurred())
-	expectedRules = []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"persistentvolumes",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"persistentvolumeclaims",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"nodes",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"pods",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-			},
-		},
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"events",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"create",
-				"patch",
-			},
-		},
-	}
-	Expect(crole.Rules).To(Equal(expectedRules))
-	Expect(crole.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
 }
 
 func verifyCreateClusterRole(cl client.Client) {
@@ -1017,34 +939,6 @@ func verifyCreateCSIRole(cl client.Client) {
 			},
 			Verbs: []string{
 				"get",
-			},
-		},
-	}
-	Expect(role.Rules).To(Equal(expectedRules))
-	Expect(role.Labels[AppKubernetesPartOfLabel]).To(Equal("testing"))
-
-	role = &rbacv1.Role{}
-	nn = types.NamespacedName{
-		Name:      healthCheckName,
-		Namespace: testNamespace,
-	}
-	err = cl.Get(context.TODO(), nn, role)
-	Expect(err).NotTo(HaveOccurred())
-	expectedRules = []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"coordination.k8s.io",
-			},
-			Resources: []string{
-				"leases",
-			},
-			Verbs: []string{
-				"get",
-				"list",
-				"watch",
-				"delete",
-				"update",
-				"create",
 			},
 		},
 	}

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -56,17 +56,16 @@ var (
 )
 
 type daemonSetArgs struct {
-	operatorImage                        string
-	provisionerImage                     string
-	externalHealthMonitorControllerImage string
-	nodeDriverRegistrarImage             string
-	livenessProbeImage                   string
-	snapshotterImage                     string
-	csiProvisionerImage                  string
-	namespace                            string
-	name                                 string
-	verbosity                            int
-	version                              string
+	operatorImage            string
+	provisionerImage         string
+	nodeDriverRegistrarImage string
+	livenessProbeImage       string
+	snapshotterImage         string
+	csiProvisionerImage      string
+	namespace                string
+	name                     string
+	verbosity                int
+	version                  string
 }
 
 // reconcileDaemonSet Reconciles the daemon set.
@@ -181,12 +180,6 @@ func getDaemonSetArgs(reqLogger logr.Logger, namespace string, legacyProvisioner
 		if res.provisionerImage == "" {
 			reqLogger.V(3).Info(fmt.Sprintf("%s not set, defaulting to %s", csiProvisionerImageEnvVarName, CsiProvisionerImageDefault))
 			res.provisionerImage = CsiProvisionerImageDefault
-		}
-
-		res.externalHealthMonitorControllerImage = os.Getenv(externalHealthMonitorControllerImageEnvVarName)
-		if res.externalHealthMonitorControllerImage == "" {
-			reqLogger.V(3).Info(fmt.Sprintf("%s not set, defaulting to %s", externalHealthMonitorControllerImageEnvVarName, CsiExternalHealthMonitorControllerImageDefault))
-			res.externalHealthMonitorControllerImage = CsiExternalHealthMonitorControllerImageDefault
 		}
 
 		res.nodeDriverRegistrarImage = os.Getenv(nodeDriverRegistrarImageEnvVarName)
@@ -592,33 +585,6 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 									MountPropagation: &biDirectional,
 								},
 								socketDirVolumeMount,
-							},
-							TerminationMessagePath:   "/dev/termination-log",
-							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-						},
-						{
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("150Mi"),
-								},
-							},
-							Name:            "csi-external-health-monitor-controller",
-							Image:           args.externalHealthMonitorControllerImage,
-							ImagePullPolicy: cr.Spec.ImagePullPolicy,
-							Args: []string{
-								fmt.Sprintf("--v=%d", args.verbosity),
-								"--csi-address=$(ADDRESS)",
-								"--leader-election",
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								socketDirVolumeMount,
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name:  "ADDRESS",
-									Value: csiSocket,
-								},
 							},
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,

--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -37,9 +37,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRoleBinding(reqLogger log
 	if err := r.reconcileRbacResource(reqLogger.WithName("Provisioner RBAC"), createClusterRoleBindingObject(ProvisionerServiceAccountNameCsi, namespace, ProvisionerServiceAccountNameCsi), createClusterRoleBindingObject(ProvisionerServiceAccountNameCsi, namespace, ProvisionerServiceAccountNameCsi), cr); err != nil {
 		return reconcile.Result{}, err
 	}
-	if err := r.reconcileRbacResource(reqLogger.WithName("Health Check RBAC"), createClusterRoleBindingObject(healthCheckName, namespace, ProvisionerServiceAccountNameCsi), createClusterRoleBindingObject(healthCheckName, namespace, ProvisionerServiceAccountNameCsi), cr); err != nil {
-		return reconcile.Result{}, err
-	}
 	if r.isLegacy(cr) {
 		if err := r.reconcileRbacResource(reqLogger.WithName("Provisioner RBAC"), createClusterRoleBindingObject(MultiPurposeHostPathProvisionerName, namespace, ProvisionerServiceAccountName), createClusterRoleBindingObject(MultiPurposeHostPathProvisionerName, namespace, ProvisionerServiceAccountName), cr); err != nil {
 			return reconcile.Result{}, err
@@ -148,9 +145,6 @@ func (r *ReconcileHostPathProvisioner) reconcileClusterRole(reqLogger logr.Logge
 		}
 	}
 	if err := r.reconcileRbacResource(reqLogger.WithName("Provisioner RBAC"), r.createCsiClusterRoleObjectProvisioner(cr), r.createCsiClusterRoleObjectProvisioner(cr), cr); err != nil {
-		return reconcile.Result{}, err
-	}
-	if err := r.reconcileRbacResource(reqLogger.WithName("Provisioner RBAC"), createClusterRoleObjectHealthCheck(), createClusterRoleObjectHealthCheck(), cr); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -416,84 +410,6 @@ func createSnapshotCsiClusterRoles() []rbacv1.PolicyRule {
 	}
 }
 
-func createClusterRoleObjectHealthCheck() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   healthCheckName,
-			Labels: getRecommendedLabels(),
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"persistentvolumes",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"persistentvolumeclaims",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"nodes",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"pods",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"events",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-					"create",
-					"patch",
-				},
-			},
-		},
-	}
-}
-
 func (r *ReconcileHostPathProvisioner) deleteClusterRoleObject(name string) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -510,9 +426,6 @@ func (r *ReconcileHostPathProvisioner) deleteClusterRoleObject(name string) erro
 
 func (r *ReconcileHostPathProvisioner) reconcileRoleBinding(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
 	if err := r.reconcileRbacResource(reqLogger.WithName("Provisioner RBAC"), createRoleBindingObject(ProvisionerServiceAccountNameCsi, namespace, ProvisionerServiceAccountNameCsi), createRoleBindingObject(ProvisionerServiceAccountNameCsi, namespace, ProvisionerServiceAccountNameCsi), cr); err != nil {
-		return reconcile.Result{}, err
-	}
-	if err := r.reconcileRbacResource(reqLogger.WithName("Health Check RBAC"), createRoleBindingObject(healthCheckName, namespace, ProvisionerServiceAccountNameCsi), createRoleBindingObject(healthCheckName, namespace, ProvisionerServiceAccountNameCsi), cr); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -543,9 +456,6 @@ func createRoleBindingObject(name, namespace, saName string) *rbacv1.RoleBinding
 
 func (r *ReconcileHostPathProvisioner) reconcileRole(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
 	if err := r.reconcileRbacResource(reqLogger.WithName("provisioner RBAC"), createRoleObjectProvisioner(namespace), createRoleObjectProvisioner(namespace), cr); err != nil {
-		return reconcile.Result{}, err
-	}
-	if err := r.reconcileRbacResource(reqLogger.WithName("healthcheck RBAC"), createRoleObjectHealthCheck(namespace), createRoleObjectHealthCheck(namespace), cr); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -601,35 +511,6 @@ func createRoleObjectProvisioner(namespace string) *rbacv1.Role {
 				},
 				Verbs: []string{
 					"get",
-				},
-			},
-		},
-	}
-}
-
-func createRoleObjectHealthCheck(namespace string) *rbacv1.Role {
-	labels := getRecommendedLabels()
-	return &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      healthCheckName,
-			Namespace: namespace,
-			Labels:    labels,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{
-					"coordination.k8s.io",
-				},
-				Resources: []string{
-					"leases",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-					"delete",
-					"update",
-					"create",
 				},
 			},
 		},

--- a/pkg/controller/hostpathprovisioner/serviceaccount.go
+++ b/pkg/controller/hostpathprovisioner/serviceaccount.go
@@ -224,7 +224,7 @@ func (r *ReconcileHostPathProvisioner) getDuplicateServiceAccount(customCrName, 
 	}
 
 	for _, sa := range saList.Items {
-		if sa.Name != ProvisionerServiceAccountName && sa.Name != healthCheckName && sa.Name != ProvisionerServiceAccountNameCsi {
+		if sa.Name != ProvisionerServiceAccountName && sa.Name != ProvisionerServiceAccountNameCsi {
 			for _, ownerRef := range sa.OwnerReferences {
 				if ownerRef.Kind == "HostPathProvisioner" && ownerRef.Name == customCrName {
 					dups = append(dups, sa)

--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -48,7 +48,6 @@ var (
 	operatorImage    = flag.String("operator-image-name", hostpathprovisioner.OperatorImageDefault, "optional")
 	provisionerImage = flag.String("provisioner-image-name", hostpathprovisioner.ProvisionerImageDefault, "optional")
 	csiDriverImage   = flag.String("csi-driver-image-name", hostpathprovisioner.CsiProvisionerImageDefault, "optional")
-	csiExternalHealthMonitorImage   = flag.String("csi-external-health-monitor-image-name", hostpathprovisioner.CsiExternalHealthMonitorControllerImageDefault, "optional")
 	csiNodeDriverRegistrarImage   = flag.String("csi-node-driver-image-name", hostpathprovisioner.CsiNodeDriverRegistrationImageDefault, "optional")
 	csiLivenessProbeImage   = flag.String("csi-liveness-probe-image-name", hostpathprovisioner.LivenessProbeImageDefault, "optional")
 	csiExternalProvisionerImage   = flag.String("csi-external-provisioner-image-name", hostpathprovisioner.CsiSigStorageProvisionerImageDefault, "optional")
@@ -73,7 +72,6 @@ func main() {
 		OperatorImage:    *operatorImage,
 		ProvisionerImage: *provisionerImage,
 		CsiDriverImage: *csiDriverImage,
-		CsiExternalHealthMonitorImage: *csiExternalHealthMonitorImage,
 		CsiNodeDriverRegistrarImage: *csiNodeDriverRegistrarImage,
 		CsiLivenessProbeImage: *csiLivenessProbeImage,
 		CsiExternalProvisionerImage: *csiExternalProvisionerImage,

--- a/tools/helper/cluster_role_generated.go
+++ b/tools/helper/cluster_role_generated.go
@@ -41,7 +41,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   resources:
   - clusterrolebindings
   verbs:
@@ -71,7 +70,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   resources:
   - clusterroles
   verbs:

--- a/tools/helper/helper.go
+++ b/tools/helper/helper.go
@@ -33,7 +33,6 @@ type OperatorArgs struct {
 	OperatorImage                 string
 	ProvisionerImage              string
 	CsiDriverImage                string
-	CsiExternalHealthMonitorImage string
 	CsiNodeDriverRegistrarImage   string
 	CsiLivenessProbeImage         string
 	CsiExternalProvisionerImage   string
@@ -60,7 +59,6 @@ func CreateOperatorDeployment(args *OperatorArgs) *appsv1.Deployment {
 	setEnvVariable("VERBOSITY", args.Verbosity, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("PROVISIONER_IMAGE", args.ProvisionerImage, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("CSI_PROVISIONER_IMAGE", args.CsiDriverImage, deployment.Spec.Template.Spec.Containers[0].Env)
-	setEnvVariable("EXTERNAL_HEALTH_MON_IMAGE", args.CsiExternalHealthMonitorImage, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("NODE_DRIVER_REG_IMAGE", args.CsiNodeDriverRegistrarImage, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("LIVENESS_PROBE_IMAGE", args.CsiLivenessProbeImage, deployment.Spec.Template.Spec.Containers[0].Env)
 	setEnvVariable("CSI_SIG_STORAGE_PROVISIONER_IMAGE", args.CsiExternalProvisionerImage, deployment.Spec.Template.Spec.Containers[0].Env)

--- a/tools/helper/operator_deployment_generated.go
+++ b/tools/helper/operator_deployment_generated.go
@@ -50,8 +50,6 @@ spec:
           value: quay.io/kubevirt/hostpath-provisioner:latest
         - name: CSI_PROVISIONER_IMAGE
           value: quay.io/kubevirt/hostpath-csi-driver:latest
-        - name: EXTERNAL_HEALTH_MON_IMAGE
-          value: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.3.0
         - name: NODE_DRIVER_REG_IMAGE
           value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
         - name: LIVENESS_PROBE_IMAGE

--- a/tools/helper/role_generated.go
+++ b/tools/helper/role_generated.go
@@ -147,7 +147,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   - hostpath-provisioner-monitoring
   resources:
   - rolebindings
@@ -160,7 +159,6 @@ rules:
   - hostpath-provisioner
   - hostpath-provisioner-admin
   - hostpath-provisioner-admin-csi
-  - hostpath-provisioner-health-check
   - hostpath-provisioner-monitoring
   resources:
   - roles


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The csi external health monitor does not yet support distributed health monitor controller https://github.com/kubernetes-csi/external-health-monitor/issues/87 So there is no reason to deploy it for the hpp at this point.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

