### PR TITLE
Remove 1 storage pool limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   storagePool: local
 ```
-Notice the storagePool parameter. This lets the provisioner know which pool to use. Once multiple pools are supported you can create multiple storage classes, each pointing to a different pool.
+Notice the storagePool parameter. This lets the provisioner know which pool to use. You can define multiple storage pools each
+with a different name.
 
 ### Custom Resource with PVCTemplate storage pool
 [Example CR](deploy/hostpathprovisioner_pvctemplate_cr.yaml) allows you specify the storage pool you wish to use as the backing storage for the persistent volumes. You specify the path to use to create volumes on the node, and the name of the storage pool. The name of the storage pool is used in the storage class to identify the pool. You also specified the PVC template to use. This causes the operator to create PVCs for each node that match the workload nodeSelector and a pod that mounts that PVC on to the node at the path specified. The hpp csi driver will then use the PVC to create directories on. If the storageClassName is not specified the default storage class will be used.
@@ -82,7 +83,8 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   storagePool: local
 ```
-Notice the storagePool parameter. This lets the provisioner know which pool to use. Once multiple pools are supported you can create multiple storage classes, each pointing to a different pool.
+Notice the storagePool parameter. This lets the provisioner know which pool to use. You can define multiple storage pools each
+pointing to a different path.
 
 ### Legacy CR
 If you are using a previous version of the hostpath provisioner operator your CR will look like this:

--- a/pkg/controller/hostpathprovisioner/storagepool.go
+++ b/pkg/controller/hostpathprovisioner/storagepool.go
@@ -302,10 +302,10 @@ func (r *ReconcileHostPathProvisioner) getStorageClassNameOrDefault(template *co
 
 func (r *ReconcileHostPathProvisioner) storagePoolPVCByNode(storagePool *hostpathprovisionerv1.StoragePool, namespace string, node *corev1.Node) *corev1.PersistentVolumeClaim {
 	labels := getRecommendedLabels()
-	labels[storagePoolLabelKey] = r.getStorageClassNameOrDefault(storagePool.PVCTemplate)
+	labels[storagePoolLabelKey] = storagePool.Name
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      getStoragePoolPVCName(r.getStorageClassNameOrDefault(storagePool.PVCTemplate), node.GetName()),
+			Name:      getStoragePoolPVCName(storagePool.Name, node.GetName()),
 			Namespace: namespace,
 			Labels:    labels,
 		},
@@ -365,7 +365,6 @@ func (r *ReconcileHostPathProvisioner) storagePoolDeploymentByNode(logger logr.L
 					},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            ProvisionerServiceAccountNameCsi,
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,
 					TerminationGracePeriodSeconds: &defaultGracePeriod,
@@ -429,7 +428,7 @@ func (r *ReconcileHostPathProvisioner) storagePoolDeploymentByNode(logger logr.L
 							Name: dataName,
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: getStoragePoolPVCName(r.getStorageClassNameOrDefault(sourceStoragePool.PVCTemplate), node.GetName()),
+									ClaimName: getStoragePoolPVCName(sourceStoragePool.Name, node.GetName()),
 								},
 							},
 						},

--- a/pkg/controller/hostpathprovisioner/storagepool_test.go
+++ b/pkg/controller/hostpathprovisioner/storagepool_test.go
@@ -252,7 +252,7 @@ func verifyDeploymentsAndPVCs(podCount, pvcCount int, cr *hppv1.HostPathProvisio
 	Expect(err).ToNot(HaveOccurred())
 	for _, pvc := range pvcList.Items {
 		foundPVCs = append(foundPVCs, pvc.Name)
-		Expect(pvc.Name).To(ContainSubstring(*cr.Spec.StoragePools[0].PVCTemplate.StorageClassName))
+		Expect(pvc.Name).To(ContainSubstring(cr.Spec.StoragePools[0].Name))
 		Expect(pvc.Spec).To(BeEquivalentTo(*cr.Spec.StoragePools[0].PVCTemplate))
 	}
 	Expect(foundPVCs).ToNot(BeEmpty(), fmt.Sprintf("%v", foundPVCs))


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixed bug with finalizer being always applied even if it didn't change. Causing a lot of concurrency issues.
Fixed bug where the PVC contained the storage class name, and not the storage pool name.
Don't allow duplicate paths or names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Allow multiple storage pools.
```

