### PR TITLE
Hash names if length over label or volume name max

### DIFF
--- a/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook.go
@@ -24,6 +24,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	maxStoragePoolNameLength = 50
+	maxPathLength            = 255
+)
+
 // SetupWebhookWithManager configures the webhook for the passed in manager
 func (r *HostPathProvisioner) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -81,8 +86,14 @@ func validateStoragePool(storagePool StoragePool) error {
 	if storagePool.Name == "" {
 		return fmt.Errorf("storagePool.name cannot be blank")
 	}
+	if len(storagePool.Name) > maxStoragePoolNameLength {
+		return fmt.Errorf("storagePool.name cannot have a length greater than 50")
+	}
 	if storagePool.Path == "" {
 		return fmt.Errorf("storagePool.path cannot be blank")
+	}
+	if len(storagePool.Path) > maxPathLength {
+		return fmt.Errorf("storagePool.path cannot have a length greater than 255")
 	}
 	return nil
 }

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -480,17 +480,24 @@ func createLegacyStoragePoolCr() *hppv1.HostPathProvisioner {
 	}
 }
 
+func createStoragePoolWithTemplateLongNameCr() *hppv1.HostPathProvisioner {
+	volumeMode := corev1.PersistentVolumeFilesystem
+	name := "l123456789012345678901234567890123456789012345678901234567890123"
+	Expect(len(name)).To(BeNumerically(">=", maxMountNameLength))
+	return createStoragePoolWithTemplateVolumeModeCr(name, &volumeMode)
+}
+
 func createStoragePoolWithTemplateCr() *hppv1.HostPathProvisioner {
 	volumeMode := corev1.PersistentVolumeFilesystem
-	return createStoragePoolWithTemplateVolumeModeCr(&volumeMode)
+	return createStoragePoolWithTemplateVolumeModeCr("local", &volumeMode)
 }
 
 func createStoragePoolWithTemplateBlockCr() *hppv1.HostPathProvisioner {
 	volumeMode := corev1.PersistentVolumeBlock
-	return createStoragePoolWithTemplateVolumeModeCr(&volumeMode)
+	return createStoragePoolWithTemplateVolumeModeCr("local", &volumeMode)
 }
 
-func createStoragePoolWithTemplateVolumeModeCr(volumeMode *corev1.PersistentVolumeMode) *hppv1.HostPathProvisioner {
+func createStoragePoolWithTemplateVolumeModeCr(name string, volumeMode *corev1.PersistentVolumeMode) *hppv1.HostPathProvisioner {
 	scName := "test"
 	return &hppv1.HostPathProvisioner{
 		ObjectMeta: metav1.ObjectMeta{
@@ -501,7 +508,7 @@ func createStoragePoolWithTemplateVolumeModeCr(volumeMode *corev1.PersistentVolu
 			ImagePullPolicy: corev1.PullAlways,
 			StoragePools: []hppv1.StoragePool{
 				{
-					Name: "local",
+					Name: name,
 					Path: "/tmp/test",
 					PVCTemplate: &corev1.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There are length limits on labels and volume names, that could be exceeded if node names + storage pool names exceeded this limit. This PR will hash the value so it will never exceed the limits. Hash the generated names if length > 63 characters (label, volume name). Also put some limits on the storage pool names. Don't allow storage pool names over 50 characters. And limits on the path lengths. Don't allow paths over 255 characters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #184 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Limit storage pool name length and path length to not exceed limits.
```

