### PR TITLE
Update CSI driver to allow for fsGroup policy.

### DIFF
--- a/pkg/controller/hostpathprovisioner/csidriver.go
+++ b/pkg/controller/hostpathprovisioner/csidriver.go
@@ -107,7 +107,7 @@ func createCSIDriverObject(namespace string) *storagev1.CSIDriver {
 	podInfoOnMount := true
 	attachRequired := false
 	storageCapacity := true
-	fsGroupPolicy := storagev1.NoneFSGroupPolicy
+	fsGroupPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy
 
 	return &storagev1.CSIDriver{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -669,6 +669,7 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 								"--immediate-topology=false",
 								"--strict-topology=true",
 								"--node-deployment=true",
+								"--default-fstype=xfs",
 							},
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: CSI driver now respects fsGroup podSecurityContext
```

