### PR TITLE
Ensure storage pool deployment sets service account

### DIFF
--- a/pkg/controller/hostpathprovisioner/storagepool.go
+++ b/pkg/controller/hostpathprovisioner/storagepool.go
@@ -366,6 +366,7 @@ func (r *ReconcileHostPathProvisioner) storagePoolDeploymentByNode(logger logr.L
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            ProvisionerServiceAccountNameCsi,
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,
 					TerminationGracePeriodSeconds: &defaultGracePeriod,

--- a/pkg/controller/hostpathprovisioner/storagepool_test.go
+++ b/pkg/controller/hostpathprovisioner/storagepool_test.go
@@ -246,6 +246,7 @@ func verifyDeploymentsAndPVCs(podCount, pvcCount int, cr *hppv1.HostPathProvisio
 		if metav1.IsControlledBy(&deployment, cr) && deployment.GetLabels()[storagePoolLabelKey] == getResourceNameWithMaxLength(storagePoolName, "hpp", maxNameLength) {
 			foundDeployments = append(foundDeployments, deployment.Name)
 		}
+		Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(ProvisionerServiceAccountNameCsi))
 	}
 	Expect(foundDeployments).ToNot(BeEmpty(), fmt.Sprintf("%v", foundDeployments))
 	Expect(len(foundDeployments)).To(Equal(podCount), fmt.Sprintf("%v", foundDeployments))


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

