### PR TITLE
Remove annotations from prometheus recording rules

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -1043,6 +1043,11 @@ func verifyCreatePrometheusResources(cl client.Client) {
 	}
 	err := cl.Get(context.TODO(), nn, rule)
 	Expect(err).NotTo(HaveOccurred())
+	for _, r := range rule.Spec.Groups[0].Rules {
+		if r.Record != "" {
+			Expect(r.Annotations).To(BeNil())
+		}
+	}
 	hppDownAlert := promv1.Rule{
 		Alert: "HPPOperatorDown",
 		Expr:  intstr.FromString("kubevirt_hpp_operator_up_total == 0"),

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -182,9 +182,6 @@ func createPrometheusRules(namespace string) []promv1.Rule {
 		generateRecordRule(
 			"kubevirt_hpp_operator_up_total",
 			fmt.Sprintf("sum(up{namespace='%s', pod=~'hostpath-provisioner-operator-.*'} or vector(0))", namespace),
-			map[string]string{
-				"summary": "The total number of running hostpath-provisioner-operator pods",
-			},
 		),
 		generateAlertRule(
 			"HPPOperatorDown",
@@ -378,11 +375,10 @@ func generateAlertRule(alert, expr, duration string, annotations, labels map[str
 	}
 }
 
-func generateRecordRule(record, expr string, annotations map[string]string) promv1.Rule {
+func generateRecordRule(record, expr string) promv1.Rule {
 	return promv1.Rule{
-		Record:      record,
-		Expr:        intstr.FromString(expr),
-		Annotations: annotations,
+		Record: record,
+		Expr:   intstr.FromString(expr),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prometheus recording rule (rule[i].Record != "") can't have an annotations field:
```bash
admission webhook \"prometheusrules.openshift.io\" denied the request: Rules are not valid
```
```bash
$ oc create -f rules.yaml
The  "prometheusrules" is invalid: : 8:13: group "hpp.rules", rule 1, "kubevirt_hpp_operator_up_total": invalid field 'annotations' in recording rule
```
https://github.com/prometheus/prometheus/blob/main/model/rulefmt/rulefmt.go#L182

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

