### PR TITLE
Make DaemonSet metrics scrapable

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -473,6 +473,7 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 	pathMounts := buildVolumeMountsFromStoragePoolInfo(storagePoolPaths)
 	biDirectional := corev1.MountPropagationBidirectional
 	labels := getRecommendedLabels()
+	labels[PrometheusLabelKey] = PrometheusLabelValue
 	ds := &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -555,6 +556,11 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 								{
 									ContainerPort: 9898,
 									Name:          "healthz",
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									ContainerPort: 8080,
+									Name:          "metrics",
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -235,6 +235,20 @@ func getAlertRules() []promv1.Rule {
 				componentAlertLabelKey: componentAlertLabelValue,
 			},
 		),
+		generateAlertRule(
+			"HPPSharingPoolPathWithOS",
+			"kubevirt_hpp_pool_path_shared_with_os == 1",
+			"1m",
+			map[string]string{
+				"summary":     "HPP pool path sharing a filesystem with OS, fix to prevent HPP PVs from causing disk pressure and affecting node operation",
+				"runbook_url": runbookURLBasePath + "HPPSharingPoolPathWithOS",
+			},
+			map[string]string{
+				severityAlertLabelKey:  "warning",
+				partOfAlertLabelKey:    partOfAlertLabelValue,
+				componentAlertLabelKey: componentAlertLabelValue,
+			},
+		),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We do this by adding the prometheus service label + port to the container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

