### PR TITLE
Fix issue with basic and pvcTemplate causing npe when removing hpp cr

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -560,6 +560,18 @@ func createStoragePoolWithTemplateVolumeModeCr(name string, volumeMode *corev1.P
 	}
 }
 
+func createStoragePoolWithTemplateVolumeModeAndBasicCr(name string, volumeMode *corev1.PersistentVolumeMode) *hppv1.HostPathProvisioner {
+	cr := createStoragePoolWithTemplateVolumeModeCr(name, volumeMode)
+	pvcTemplate := cr.Spec.StoragePools[0]
+	cr.Spec.StoragePools = make([]hppv1.StoragePool, 0)
+	cr.Spec.StoragePools = append(cr.Spec.StoragePools, hppv1.StoragePool{
+		Name: "basic",
+		Path: "/tmp/basic",
+	})
+	cr.Spec.StoragePools = append(cr.Spec.StoragePools, pvcTemplate)
+	return cr
+}
+
 // After this has run, the returned cr state should be available, not progressing and not degraded.
 func createDeployedCr(cr *hppv1.HostPathProvisioner) (*hppv1.HostPathProvisioner, *ReconcileHostPathProvisioner, client.Client) {
 	objs := []runtime.Object{cr}


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On an hpp CR that has both basic and pvcTemplate storage pool, removing the CR would cause a npe.
For example if you use a template that uses ceph as its pvcTemplate.
```yaml
apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
kind: HostPathProvisioner
metadata:
  name: hostpath-provisioner
spec:
  imagePullPolicy: Always
  storagePools:
      - name: local-basic
        path: "/var/local-basic"
      - name: local-pvc-template
        pvcTemplate:
          volumeMode: Block   # Can be Filesystem
          storageClassName: rook-ceph-block
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
              storage: 5Gi
        path: "/var/hpvolumes"
  workload:
   nodeSelector:
     kubernetes.io/os: linux

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: HPP CR with basic storage pool and pvcTemplate storage pool would cause npe when removing storage pool.
```

