### PR TITLE
Add test cases for runbook URLs

### DIFF
--- a/pkg/controller/hostpathprovisioner/prometheus_test.go
+++ b/pkg/controller/hostpathprovisioner/prometheus_test.go
@@ -1,0 +1,22 @@
+package hostpathprovisioner
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("HPP alerts", func() {
+	Context("runbooks", func() {
+		It("Should have available URLs", func() {
+			for _, rule := range getAlertRules() {
+				Expect(rule.Annotations).ToNot(BeNil())
+				url, ok := rule.Annotations["runbook_url"]
+				Expect(ok).To(BeTrue())
+				resp, err := http.Head(url)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			}
+		})
+	})
+})


### PR DESCRIPTION
This PR adds new tests cases for alert definitions. We expect to see "runbook_url" annotations in alerts and those urls must be accessible.

Signed-off-by: assafad <aadmi@redhat.com>

```release-note
None
```

