### PR TITLE
Use array: "string" for "spec.storagePools.pvcTemplate.accessModes" in alm-examples

### DIFF
--- a/tools/csv-generator.go
+++ b/tools/csv-generator.go
@@ -163,7 +163,9 @@ Hostpath provisioner is a local storage provisioner that uses kubernetes hostpat
 					{
 						"name": "local",
 						"pvcTemplate": {
-							"accessModes": "ReadWriteOnce",
+							"accessModes": [
+								"ReadWriteOnce"
+							],
 							"resources": {
 								"requests": {
 									"storage": "50Gi"


### PR DESCRIPTION
…cTemplate.accessModes".

Error "Invalid value: "string": spec.storagePools.pvcTemplate.accessModes in body must be of type array: "string"" for field "spec.storagePools.pvcTemplate.accessModes".

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Default template when in Create HostPathProvisioner YAML View of OpenShift Web Console contains incorrect type.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change spec.storagePools.pvcTemplate.accessModes to array of strings in alm-examples 
```

