### PR TITLE
Add an infra label to each of HPP alerts

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -1107,6 +1107,7 @@ func verifyCreatePrometheusResources(cl client.Client) {
 			"severity":                      "warning",
 			"kubernetes_operator_part_of":   "kubevirt",
 			"kubernetes_operator_component": "hostpath-provisioner-operator",
+			"infra_alert":                   "true",
 		},
 	}
 	Expect(rule.Spec.Groups[0].Rules).To(ContainElement(hppDownAlert))

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -47,6 +47,7 @@ const (
 	partOfAlertLabelValue    = "kubevirt"
 	componentAlertLabelKey   = "kubernetes_operator_component"
 	componentAlertLabelValue = "hostpath-provisioner-operator"
+	infraAlertLabelKey       = "infra_alert"
 )
 
 func (r *ReconcileHostPathProvisioner) reconcilePrometheusInfra(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
@@ -221,6 +222,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -235,6 +237,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -249,6 +252,7 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
+				infraAlertLabelKey:     "true",
 			},
 		),
 	}


### PR DESCRIPTION
This PR adds a boolean label to each of HPP alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 
For more info, please see [#7796](https://github.com/kubevirt/kubevirt/pull/7796).

Signed-off-by: assafad [aadmi@redhat.com](mailto:aadmi@redhat.com)

```release-note
None
```