### PR TITLE
Revert infra_label for HPP alerts

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -1107,7 +1107,6 @@ func verifyCreatePrometheusResources(cl client.Client) {
 			"severity":                      "warning",
 			"kubernetes_operator_part_of":   "kubevirt",
 			"kubernetes_operator_component": "hostpath-provisioner-operator",
-			"infra_alert":                   "true",
 		},
 	}
 	Expect(rule.Spec.Groups[0].Rules).To(ContainElement(hppDownAlert))

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -47,7 +47,6 @@ const (
 	partOfAlertLabelValue    = "kubevirt"
 	componentAlertLabelKey   = "kubernetes_operator_component"
 	componentAlertLabelValue = "hostpath-provisioner-operator"
-	infraAlertLabelKey       = "infra_alert"
 )
 
 func (r *ReconcileHostPathProvisioner) reconcilePrometheusInfra(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
@@ -222,7 +221,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -237,7 +235,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 		generateAlertRule(
@@ -252,7 +249,6 @@ func getAlertRules() []promv1.Rule {
 				severityAlertLabelKey:  "warning",
 				partOfAlertLabelKey:    partOfAlertLabelValue,
 				componentAlertLabelKey: componentAlertLabelValue,
-				infraAlertLabelKey:     "true",
 			},
 		),
 	}


### PR DESCRIPTION
Reverts [#239](https://github.com/kubevirt/hostpath-provisioner-operator/pull/239). The design is not yet agreed as a standard for all operators alerts, so this label won't be used for now.

Signed-off-by: assafad <aadmi@redhat.com>


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

