### PR TITLE
Use buildah instead of docker, support multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ manifest: image
 push: clean manifest manifest-push
 
 manifest-push:
-	buildah manifest push $(BUILDAH_PUSH_FLAGS) --all $(DOCKER_REPO)/$(OPERATOR_IMAGE):local docker://$(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG)
+	buildah manifest push --all $(DOCKER_REPO)/$(OPERATOR_IMAGE):local docker://$(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG)
 
 generate:
 	./hack/update-codegen.sh

--- a/Makefile
+++ b/Makefile
@@ -16,23 +16,26 @@ OPERATOR_IMAGE?=hostpath-provisioner-operator
 TAG?=latest
 DOCKER_REPO?=quay.io/kubevirt
 
+export GOLANG_VER
+export TAG
+
 all: test build
 
 operator:
-	GOLANG_VER=${GOLANG_VER} ./hack/build-operator.sh
+	./hack/build-operator.sh
 
 mounter:
-	GOLANG_VER=${GOLANG_VER} ./hack/build-mounter.sh
+	./hack/build-mounter.sh
 
 csv-generator:
-	GOLANG_VER=${GOLANG_VER} ./hack/build-csv-generator.sh
+	./hack/build-csv-generator.sh
 
 crd-generator: generate-crd
-	GOLANG_VER=${GOLANG_VER} ./hack/build-crd-generator.sh
+	./hack/build-crd-generator.sh
 	_out/crd-generator --sourcefile=./deploy/operator.yaml --outputDir=./tools/helper
 
 image: operator mounter csv-generator
-	TAG=$(TAG) ./hack/version.sh ./_out; \
+	./hack/version.sh ./_out; \
 	docker build -t $(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG) -f Dockerfile .
 
 push: image


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
hostpath-provisioner-operator part of fixing https://github.com/kubevirt/hostpath-provisioner/issues/98, we also need to change project-infra for both projects.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use buildah and podman, enable building multi-arch manifests
```

