### PR TITLE
Modify operator deployment so it can run with restricted security profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY _out/hostpath-provisioner-operator /usr/bin/hostpath-provisioner-operator
 COPY _out/csv-generator /usr/bin/csv-generator
 COPY _out/mounter /usr/bin/mounter
 COPY _out/version.txt /version.txt
+USER 1000
 ENV PATH=/usr/bin
 ENTRYPOINT ["hostpath-provisioner-operator"]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ TAG?=latest
 DOCKER_REPO?=quay.io/kubevirt
 GOOS?=linux
 GOARCH?=amd64
+BUILDAH_TLS_VERIFY?=true
 BUILDAH_PLATFORM_FLAG?=--platform $(GOOS)/$(GOARCH)
 
 export GOLANG_VER
@@ -50,7 +51,7 @@ manifest: image
 push: clean manifest manifest-push
 
 manifest-push:
-	buildah manifest push --all $(DOCKER_REPO)/$(OPERATOR_IMAGE):local docker://$(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG)
+	buildah manifest push --tls-verify=${BUILDAH_TLS_VERIFY} --all $(DOCKER_REPO)/$(OPERATOR_IMAGE):local docker://$(DOCKER_REPO)/$(OPERATOR_IMAGE):$(TAG)
 
 generate:
 	./hack/update-codegen.sh

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1807,6 +1807,13 @@ spec:
           command:
           - hostpath-provisioner-operator
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           livenessProbe:
             failureThreshold: 1
             httpGet:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Modify operator deployment so it can run with restricted security profile

Also Allow pushing to insecure registry by setting env variable.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Modify operator deployment so it can run with restricted security profile
```

