### PR TITLE
Add support to deploy HPP locally on kubevirtci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,12 @@ generate-doc: build-docgen
 
 build-docgen:
 	go build -ldflags="-s -w" -o _out/metricsdocs ./tools/metricsdocs
+
+cluster-up:
+	./cluster/up.sh
+
+cluster-sync:
+	./cluster/sync.sh
+
+cluster-down:
+	./cluster/down.sh

--- a/cluster/config.sh
+++ b/cluster/config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  This file is part of the hostpath-provisioner-operator project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Copyright 2022 Red Hat, Inc.
+#
+
+CERT_MANAGER_VERSION=1.7.1

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#  This file is part of the hostpath-provisioner-operator project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Copyright 2022 Red Hat, Inc.
+#
+
+set -ex
+
+source ./cluster/kubevirtci.sh
+kubevirtci::install
+
+"$(kubevirtci::path)"/cluster-up/down.sh

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#  This file is part of the hostpath-provisioner-operator project
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# 
+#  Copyright 2022 Red Hat, Inc.
+# 
+
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
+export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+
+KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
+
+function kubevirtci::install() {
+    if [ ! -d "${KUBEVIRTCI_PATH}" ]; then
+        git clone https://github.com/kubevirt/kubevirtci.git "${KUBEVIRTCI_PATH}"
+        (
+            cd "${KUBEVIRTCI_PATH}" || exit 1
+            git checkout tags/"${KUBEVIRTCI_TAG}" -b "${KUBEVIRTCI_TAG}"
+        )
+    fi
+}
+
+function kubevirtci::path() {
+    echo -n "${KUBEVIRTCI_PATH}"
+}
+
+function kubevirtci::kubeconfig() {
+    echo -n "${KUBEVIRTCI_PATH}"/_ci-configs/"${KUBEVIRT_PROVIDER}"/.kubeconfig
+}
+

--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#  This file is part of the hostpath-provisioner-operator project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Copyright 2022 Red Hat, Inc.
+#
+
+set -ex
+
+source ./cluster/config.sh
+source ./cluster/kubevirtci.sh
+
+KUBEVIRTCI_PATH=$(kubevirtci::path)
+KUBECTL=$(which kubectl 2> /dev/null) || (echo "could not find kubectl executable" && exit 1)
+
+export KUBECONFIG=$(kubevirtci::kubeconfig)
+
+# install cert-manager
+${KUBECTL} apply -f https://github.com/cert-manager/cert-manager/releases/download/v"${CERT_MANAGER_VERSION}"/cert-manager.yaml
+${KUBECTL} wait --for=condition=Available --namespace cert-manager --timeout 120s --all deployments
+
+# install hostpath-provisioner-operator
+make build
+
+${KUBECTL} apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/namespace.yaml
+${KUBECTL} apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/webhook.yaml --namespace hostpath-provisioner
+${KUBECTL} apply -f https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/main/deploy/operator.yaml --namespace hostpath-provisioner

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#  This file is part of the hostpath-provisioner-operator project
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Copyright 2022 Red Hat, Inc.
+#
+
+set -ex
+
+source ./cluster/kubevirtci.sh
+kubevirtci::install
+
+"$(kubevirtci::path)"/cluster-up/up.sh


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

I'm planning to add functional tests for HPO alerts. For convenience, it would be easier if we could easily deploy a local cluster with HPO, and run these tests against it. Most other components, like HCO, kubevirt, CDI are already using this approach.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to deploy HPP locally on kubevirtci
```

