### PR TITLE
Specify GOARCH even when our Go is from gimme

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -16,6 +16,8 @@ GOLANG_VER=${GOLANG_VER:-1.18.2}
 
 function setGoInProw() {
   if [[ -v PROW_JOB_ID ]] ; then
+    export GIMME_HOSTARCH=amd64
+    export GIMME_ARCH=${GOARCH}
     eval $(gimme ${1})
     cp -R ~/.gimme/versions/go${1}.linux.amd64 /usr/local/go
   fi


### PR DESCRIPTION
Before these changes, gimme go will `unset GOARCH` and we will always build amd64 binaries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/hostpath-provisioner/issues/139

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug where the published arm64 docker images were built with amd64 binaries.
```

