### PR TITLE
Add `operator_health_impact` label to HPP alerts

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -1107,6 +1107,7 @@ func verifyCreatePrometheusResources(cl client.Client) {
 		},
 		Labels: map[string]string{
 			"severity":                      "warning",
+			"operator_health_impact":        "critical",
 			"kubernetes_operator_part_of":   "kubevirt",
 			"kubernetes_operator_component": "hostpath-provisioner-operator",
 		},

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -37,16 +37,17 @@ import (
 )
 
 const (
-	ruleName                 = "prometheus-hpp-rules"
-	rbacName                 = "hostpath-provisioner-monitoring"
-	monitorName              = "service-monitor-hpp"
-	defaultMonitoringNs      = "monitoring"
-	runbookURLBasePath       = "https://kubevirt.io/monitoring/runbooks/"
-	severityAlertLabelKey    = "severity"
-	partOfAlertLabelKey      = "kubernetes_operator_part_of"
-	partOfAlertLabelValue    = "kubevirt"
-	componentAlertLabelKey   = "kubernetes_operator_component"
-	componentAlertLabelValue = "hostpath-provisioner-operator"
+	ruleName                  = "prometheus-hpp-rules"
+	rbacName                  = "hostpath-provisioner-monitoring"
+	monitorName               = "service-monitor-hpp"
+	defaultMonitoringNs       = "monitoring"
+	runbookURLBasePath        = "https://kubevirt.io/monitoring/runbooks/"
+	severityAlertLabelKey     = "severity"
+	healthImpactAlertLabelKey = "operator_health_impact"
+	partOfAlertLabelKey       = "kubernetes_operator_part_of"
+	partOfAlertLabelValue     = "kubevirt"
+	componentAlertLabelKey    = "kubernetes_operator_component"
+	componentAlertLabelValue  = "hostpath-provisioner-operator"
 )
 
 func (r *ReconcileHostPathProvisioner) reconcilePrometheusInfra(reqLogger logr.Logger, cr *hostpathprovisionerv1.HostPathProvisioner, namespace string) (reconcile.Result, error) {
@@ -218,9 +219,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "HPPOperatorDown",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "critical",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -232,9 +234,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "HPPNotReady",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "critical",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 		generateAlertRule(
@@ -246,9 +249,10 @@ func getAlertRules() []promv1.Rule {
 				"runbook_url": runbookURLBasePath + "HPPSharingPoolPathWithOS",
 			},
 			map[string]string{
-				severityAlertLabelKey:  "warning",
-				partOfAlertLabelKey:    partOfAlertLabelValue,
-				componentAlertLabelKey: componentAlertLabelValue,
+				severityAlertLabelKey:     "warning",
+				healthImpactAlertLabelKey: "warning",
+				partOfAlertLabelKey:       partOfAlertLabelValue,
+				componentAlertLabelKey:    componentAlertLabelValue,
 			},
 		),
 	}


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds to each of HPP alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires due to an issue that impacts the operator's functionality badly, and an action must be taken immediately in order to solve it.
-  `warning` indicates that the alert fires due to an issue that soon might impact the operator's functionality badly, and the user should be warned in order to solve the issue.
- `none` indicates that the alert fires due to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself.


**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/CNV-18923


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

