### PR TITLE
Fix crash with different Go compiler: remove extra flags in build command

### DIFF
--- a/hack/build-crd-generator.sh
+++ b/hack/build-crd-generator.sh
@@ -17,4 +17,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 ensureArmAvailable
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/crd-generator tools/crd-generator/crd-generator.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/crd-generator tools/crd-generator/crd-generator.go

--- a/hack/build-csv-generator.sh
+++ b/hack/build-csv-generator.sh
@@ -17,4 +17,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 ensureArmAvailable
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/csv-generator tools/csv-generator.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/csv-generator tools/csv-generator.go

--- a/hack/build-mounter.sh
+++ b/hack/build-mounter.sh
@@ -17,4 +17,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 ensureArmAvailable
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/mounter cmd/mounter/*.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/mounter cmd/mounter/*.go

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -17,4 +17,4 @@ script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source "${script_dir}"/common.sh
 ensureArmAvailable
 
-CGO_ENABLED=1 go build -a -tags strictfipsruntime -ldflags '-extldflags' -o _out/hostpath-provisioner-operator cmd/manager/main.go
+CGO_ENABLED=1 go build -a -tags strictfipsruntime -o _out/hostpath-provisioner-operator cmd/manager/main.go


### PR DESCRIPTION
Previously the flags were:
-ldflags '-extldflags "-static"'
Or: "Pass the flag -static to the linker"
We removed the "-static" part in #318, so we don't need these flags any more.

This seems to be harmless on our CI, but when I've built the code with a different Go compiler/ld, it caused the binary to crash.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

