### PR TITLE
Update to the latest Go (1.20) and don't specify z-stream

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-GOLANG_VER=${GOLANG_VER:-1.19.4}
+GOLANG_VER=${GOLANG_VER:-1.20}
 
 function ensureArmAvailable() {
   if [[ -v PROW_JOB_ID && GOARCH="arm64" ]] ; then


### PR DESCRIPTION
We are falling behind on updating z-stream, let's avoid the problem entirely by using a floating tag.

**What this PR does / why we need it**:
I noticed I had to update some older branches away from 1.19.4, when 1.19.12 is the latest z-stream on the 1.19 branch.
Instead of having to keep up, let's try a floating tag.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Build using Go 1.20
```

