### PR TITLE
Update HPP CR conditions correctly when degraded

### DIFF
--- a/pkg/controller/hostpathprovisioner/controller.go
+++ b/pkg/controller/hostpathprovisioner/controller.go
@@ -621,17 +621,8 @@ func (r *ReconcileHostPathProvisioner) checkDegraded(logger logr.Logger, cr *hos
 
 	logger.V(3).Info("Degraded check", "Degraded", degraded)
 
-	// If deployed and degraded, mark degraded, otherwise we are still deploying or not degraded.
 	if degraded && !r.isDeploying(cr) {
-		conditions.SetStatusCondition(&cr.Status.Conditions, conditions.Condition{
-			Type:   conditions.ConditionDegraded,
-			Status: corev1.ConditionTrue,
-		})
-	} else {
-		conditions.SetStatusCondition(&cr.Status.Conditions, conditions.Condition{
-			Type:   conditions.ConditionDegraded,
-			Status: corev1.ConditionFalse,
-		})
+		MarkCrFailed(cr, "Degraded", "CR is deployed but DaemonSets are not ready")
 	}
 
 	logger.V(3).Info("Finished degraded check", "conditions", cr.Status.Conditions)

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -300,10 +300,9 @@ var _ = Describe("Controller reconcile loop", func() {
 		Expect(updatedCr.Status.OperatorVersion).To(Equal("1.0.3"))
 		Expect(updatedCr.Status.ObservedVersion).To(Equal("1.0.2"))
 		Expect(updatedCr.Status.TargetVersion).To(Equal("1.0.3"))
-		// Didn't make daemonset unavailable, so should be fully healthy
-		Expect(conditions.IsStatusConditionTrue(updatedCr.Status.Conditions, conditions.ConditionAvailable)).To(BeTrue())
-		Expect(conditions.IsStatusConditionTrue(updatedCr.Status.Conditions, conditions.ConditionProgressing)).To(BeTrue())
-		// It should be degraded
+		// Deployed, but NumberReady < DesiredNumberScheduled, so should be Available:False,Progressing:False,Degraded:True
+		Expect(conditions.IsStatusConditionTrue(updatedCr.Status.Conditions, conditions.ConditionAvailable)).To(BeFalse())
+		Expect(conditions.IsStatusConditionTrue(updatedCr.Status.Conditions, conditions.ConditionProgressing)).To(BeFalse())
 		Expect(conditions.IsStatusConditionTrue(updatedCr.Status.Conditions, conditions.ConditionDegraded)).To(BeTrue())
 
 		ds = &appsv1.DaemonSet{}


### PR DESCRIPTION
**What this PR does / why we need it**:
ConditionAvailable was not updated to False, so kubevirt_hpp_cr_ready was not updated to 0, and HPPNotReady was not fires.

**Which issue(s) this PR fixes**:
Fixes bz #2213255

**Special notes for your reviewer**:
Func test coverage to be added in [hostpath-provisioner](https://github.com/kubevirt/hostpath-provisioner/blob/main/tests/prometheus_test.go#L137-L157)

**Release note**:
```release-note
Update HPP CR conditions correctly when degraded
```

