### PR TITLE
Only cache hpp ns as we did previously

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -88,6 +89,11 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				namespace: {},
+			},
+		},
 		LeaderElectionNamespace: namespace,
 		HealthProbeBindAddress:  "0.0.0.0:6060",
 		ReadinessEndpointName:   "/readyz",

--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -435,7 +435,7 @@ func (r *ReconcileHostPathProvisioner) checkPrometheusUsed() (bool, error) {
 	// Check if we are using prometheus, if not return false.
 	listObj := &promv1.PrometheusRuleList{}
 	if err := r.client.List(context.TODO(), listObj); err != nil {
-		if meta.IsNoMatchError(err) {
+		if meta.IsNoMatchError(err) || strings.Contains(err.Error(), "failed to find API group") {
 			// prometheus not deployed
 			return false, nil
 		}

--- a/pkg/controller/hostpathprovisioner/scc.go
+++ b/pkg/controller/hostpathprovisioner/scc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	secv1 "github.com/openshift/api/security/v1"
@@ -209,7 +210,7 @@ func (r *ReconcileHostPathProvisioner) checkSCCUsed() (bool, error) {
 	// Check if we are using security context constraints, if not return false.
 	listObj := &secv1.SecurityContextConstraintsList{}
 	if err := r.client.List(context.TODO(), listObj); err != nil {
-		if meta.IsNoMatchError(err) {
+		if meta.IsNoMatchError(err) || strings.Contains(err.Error(), "failed to find API group") {
 			// not using SCCs
 			return false, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We dropped the "Namespace" knob as part of the migration to ctrl runtime 0.16,
https://github.com/kubevirt/hostpath-provisioner-operator/pull/372/files#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633L92
this means the cached client attempts to watch all resources cluster-wide.
This PR changes that to the previous behavior of only caching the specific hpp namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Only cache hpp namespace
```

