### PR TITLE
Handle NFS pvcs

### DIFF
--- a/pkg/controller/hostpathprovisioner/common.go
+++ b/pkg/controller/hostpathprovisioner/common.go
@@ -24,13 +24,13 @@ const (
 	// CsiProvisionerImageDefault is the default value of the hostpath provisioner csi container image name.
 	CsiProvisionerImageDefault = "hostpath-provisioner-csi"
 	// CsiNodeDriverRegistrationImageDefault is the default value of the sig storage csi node registration side car container image name.
-	CsiNodeDriverRegistrationImageDefault = "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0"
+	CsiNodeDriverRegistrationImageDefault = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0"
 	// LivenessProbeImageDefault is the default value of the liveness probe side car container image name.
-	LivenessProbeImageDefault = "k8s.gcr.io/sig-storage/livenessprobe:v2.3.0"
+	LivenessProbeImageDefault = "registry.k8s.io/sig-storage/livenessprobe:v2.3.0"
 	// SnapshotterImageDefault is the default value of the csi snapshotter side car container image name.
-	SnapshotterImageDefault = "k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1"
+	SnapshotterImageDefault = "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.1"
 	// CsiSigStorageProvisionerImageDefault is the default value of the sig storage csi provisioner side car container image name.
-	CsiSigStorageProvisionerImageDefault = "k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1"
+	CsiSigStorageProvisionerImageDefault = "registry.k8s.io/sig-storage/csi-provisioner:v3.4.1"
 
 	operatorImageEnvVarName                 = "OPERATOR_IMAGE"
 	provisionerImageEnvVarName              = "PROVISIONER_IMAGE"

--- a/pkg/controller/hostpathprovisioner/storagepool_test.go
+++ b/pkg/controller/hostpathprovisioner/storagepool_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	hppv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
 	"kubevirt.io/hostpath-provisioner-operator/version"
@@ -147,6 +148,10 @@ var _ = ginkgo.Describe("Controller reconcile loop", func() {
 			gomega.Expect(jobList.Items[0].GetName()).To(gomega.Equal("cleanup-pool-local-node1"))
 			gomega.Expect(jobList.Items[0].Labels[AppKubernetesPartOfLabel]).To(gomega.Equal("testing"))
 			gomega.Expect(jobList.Items[0].Spec.Template.Labels[AppKubernetesPartOfLabel]).To(gomega.Equal("testing"))
+			gomega.Expect(jobList.Items[0].Spec.Template.Spec.Containers).To(gomega.HaveLen(1))
+			gomega.Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].SecurityContext).ToNot(gomega.BeNil())
+			gomega.Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(gomega.Equal(pointer.Int64(0)))
+			gomega.Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(gomega.Equal(pointer.Bool(true)))
 		})
 
 		ginkgo.It("Status length should remain at one with legacy CR", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
NFS PVCs need to be looked up by target instead of the source from findmnt. First try by source, and if the source is not found try looking up the target using the source.

Fixed some minor usage of pointer and other minor linter issues.
Updated the default csi-provisioner container to be newer so it works on newer k8s versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #377 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Handle NFS PVC templates properly
```

