### PR TITLE
Restore permissions to lease in the deployment namespace so the operator can give them to the csi-provisioner

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -320,8 +320,11 @@ rules:
   - leases
   verbs:
   - get
+  - list
+  - watch
   - update
   - create
+  - delete
 - apiGroups:
   - "storage.k8s.io"
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Need to give some extra lease permissions to theoperator, so it can give those permissions to the csi-provisioner sidecar.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

