### PR TITLE
Revert to using controller-runtime registry for metrics

### DIFF
--- a/pkg/monitoring/metrics/metrics.go
+++ b/pkg/monitoring/metrics/metrics.go
@@ -17,10 +17,15 @@ limitations under the License.
 // Package metrics is the main prometheus metrics package
 package metrics
 
-import "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
 
 // SetupMetrics register the metrics
 func SetupMetrics() error {
+	operatormetrics.Register = metrics.Registry.Register
+
 	return operatormetrics.RegisterMetrics(
 		operatorMetrics,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Before https://github.com/kubevirt/hostpath-provisioner-operator/pull/405, HPO was using `controller-runtime` metrics registry to register the operator metrics. In that PR, since its using the defaults, it started using Prometheus client-go registry.

This PR reverts to using the `controller-runtime` metrics

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert to using controller-runtime registry for metrics
```

