### PR TITLE
Add PV patch RBAC for external provisioner sidecar

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,6 +18,7 @@ rules:
   - watch
   - create
   - delete
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -732,6 +732,7 @@ func verifyCreateCSIClusterRole(cl client.Client, enableSnapshot bool) {
 				"watch",
 				"create",
 				"delete",
+				"patch",
 			},
 		},
 		{

--- a/pkg/controller/hostpathprovisioner/rbac.go
+++ b/pkg/controller/hostpathprovisioner/rbac.go
@@ -250,6 +250,7 @@ func (r *ReconcileHostPathProvisioner) createCsiClusterRoleObjectProvisioner(cr 
 					"watch",
 					"create",
 					"delete",
+					"patch",
 				},
 			},
 			{

--- a/tools/helper/cluster_role_generated.go
+++ b/tools/helper/cluster_role_generated.go
@@ -18,6 +18,7 @@ rules:
   - watch
   - create
   - delete
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For newer versions of the sidecar, this is needed to achieve PV finalizer orchestration.
```
E1219 13:01:22.150741       1 controller.go:1025] error syncing volume "pvc-45bfe11e-d5e3-4275-8df0-652f84de15a7": persistentvolumes "pvc-45bfe11e-d5e3-4275-8df0-652f84de15a7" is forbidden: User "system:serviceaccount:openshift-cnv:hostpath-provisioner-admin-csi" cannot patch resource "persistentvolumes" in API group "" at the cluster scope
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/CNV-53956

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: PVs of HPP are stuck Terminating
```

