### PR TITLE
Stop using deprecated webhook validator interface.

### DIFF
--- a/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,20 +38,20 @@ func (r *HostPathProvisioner) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-var _ webhook.Validator = &HostPathProvisioner{}
+var _ webhook.CustomValidator = &HostPathProvisioner{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *HostPathProvisioner) ValidateCreate() (admission.Warnings, error) {
+func (r *HostPathProvisioner) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
 	return r.validatePathConfigAndStoragePools()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *HostPathProvisioner) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (r *HostPathProvisioner) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
 	return r.validatePathConfigAndStoragePools()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *HostPathProvisioner) ValidateDelete() (admission.Warnings, error) {
+func (r *HostPathProvisioner) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
 	return nil, nil
 }
 

--- a/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook_test.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/hostpathprovisioner_webhook_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -188,43 +189,43 @@ var _ = ginkgo.Describe("validating webhook", func() {
 	ginkgo.Context("admission", func() {
 		ginkgo.It("Either legacy or volume sources have to be set.", func() {
 			hppCr := HostPathProvisioner{}
-			_, err := hppCr.ValidateCreate()
+			_, err := hppCr.ValidateCreate(context.Background(), &hppCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("either pathConfig or storage pools must be set")))
 		})
 		ginkgo.It("Both legacy or volume sources cannot to be set.", func() {
-			_, err := bothLegacyAndVolumeCR.ValidateCreate()
+			_, err := bothLegacyAndVolumeCR.ValidateCreate(context.Background(), &bothLegacyAndVolumeCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("pathConfig and storage pools cannot be both set")))
 		})
 		ginkgo.It("Cannot have blank kind in volume source", func() {
-			_, err := blankNameCr1.ValidateCreate()
+			_, err := blankNameCr1.ValidateCreate(context.Background(), &blankNameCr1)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot be blank")))
-			_, err = blankNameCr2.ValidateCreate()
+			_, err = blankNameCr2.ValidateCreate(context.Background(), &blankNameCr2)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot be blank")))
 		})
 		ginkgo.It("Cannot have blank path in volume source", func() {
-			_, err := blankPathCr1.ValidateCreate()
+			_, err := blankPathCr1.ValidateCreate(context.Background(), &blankPathCr1)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot be blank")))
-			_, err = blankPathCr2.ValidateCreate()
+			_, err = blankPathCr2.ValidateCreate(context.Background(), &blankPathCr2)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot be blank")))
 		})
 		ginkgo.It("If pathConfig exists, path must be set", func() {
-			_, err := invalidPathConfigCR.ValidateCreate()
+			_, err := invalidPathConfigCR.ValidateCreate(context.Background(), &invalidPathConfigCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("pathconfig path must be set")))
 		})
 		ginkgo.It("Should not allow duplicate paths", func() {
-			_, err := multiSourceVolumeDuplicatePathCR.ValidateCreate()
+			_, err := multiSourceVolumeDuplicatePathCR.ValidateCreate(context.Background(), &multiSourceVolumeDuplicatePathCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("spec.storagePools[2].path is the same as spec.storagePools[0].path, cannot have duplicate paths")))
 		})
 		ginkgo.It("Should not allow duplicate names", func() {
-			_, err := multiSourceVolumeDuplicateNameCR.ValidateCreate()
+			_, err := multiSourceVolumeDuplicateNameCR.ValidateCreate(context.Background(), &multiSourceVolumeDuplicateNameCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("spec.storagePools[2].name is the same as spec.storagePools[0].name, cannot have duplicate names")))
 		})
 		ginkgo.It("Should not allow storagepool.name length > 50", func() {
-			_, err := longNameCr.ValidateCreate()
+			_, err := longNameCr.ValidateCreate(context.Background(), &longNameCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot have a length greater than 50")))
 		})
 		ginkgo.It("Should not allow storagepool.path length > 255", func() {
-			_, err := longPathCr.ValidateCreate()
+			_, err := longPathCr.ValidateCreate(context.Background(), &longPathCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot have a length greater than 255")))
 		})
 	})
@@ -232,39 +233,39 @@ var _ = ginkgo.Describe("validating webhook", func() {
 	ginkgo.Context("update", func() {
 		ginkgo.It("Either legacy or volume sources have to be set.", func() {
 			hppCr := HostPathProvisioner{}
-			_, err := hppCr.ValidateUpdate(&HostPathProvisioner{})
+			_, err := hppCr.ValidateUpdate(context.Background(), &hppCr, &hppCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("either pathConfig or storage pools must be set")))
 		})
 		ginkgo.It("Both legacy or volume sources cannot to be set.", func() {
-			_, err := bothLegacyAndVolumeCR.ValidateUpdate(&HostPathProvisioner{})
+			_, err := bothLegacyAndVolumeCR.ValidateUpdate(context.Background(), &bothLegacyAndVolumeCR, &bothLegacyAndVolumeCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("pathConfig and storage pools cannot be both set")))
 		})
 		ginkgo.It("Cannot have blank kind in volume source", func() {
-			_, err := blankNameCr1.ValidateUpdate(&HostPathProvisioner{})
+			_, err := blankNameCr1.ValidateUpdate(context.Background(), &blankNameCr1, &blankNameCr1)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot be blank")))
-			_, err = blankNameCr2.ValidateUpdate(&HostPathProvisioner{})
+			_, err = blankNameCr2.ValidateUpdate(context.Background(), &blankNameCr2, &blankNameCr2)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot be blank")))
 		})
 		ginkgo.It("Cannot have blank path in volume source", func() {
-			_, err := blankPathCr1.ValidateUpdate(&HostPathProvisioner{})
+			_, err := blankPathCr1.ValidateUpdate(context.Background(), &blankPathCr1, &blankPathCr1)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot be blank")))
-			_, err = blankPathCr2.ValidateUpdate(&HostPathProvisioner{})
+			_, err = blankPathCr2.ValidateUpdate(context.Background(), &blankPathCr2, &blankPathCr2)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot be blank")))
 		})
 		ginkgo.It("Should not allow duplicate paths", func() {
-			_, err := multiSourceVolumeDuplicatePathCR.ValidateUpdate(&HostPathProvisioner{})
+			_, err := multiSourceVolumeDuplicatePathCR.ValidateUpdate(context.Background(), &multiSourceVolumeDuplicatePathCR, &multiSourceVolumeDuplicatePathCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("spec.storagePools[2].path is the same as spec.storagePools[0].path, cannot have duplicate paths")))
 		})
 		ginkgo.It("Should not allow duplicate names", func() {
-			_, err := multiSourceVolumeDuplicateNameCR.ValidateUpdate(&HostPathProvisioner{})
+			_, err := multiSourceVolumeDuplicateNameCR.ValidateUpdate(context.Background(), &multiSourceVolumeDuplicateNameCR, &multiSourceVolumeDuplicateNameCR)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("spec.storagePools[2].name is the same as spec.storagePools[0].name, cannot have duplicate names")))
 		})
 		ginkgo.It("Should not allow storagepool.name length > 50", func() {
-			_, err := longNameCr.ValidateUpdate(&HostPathProvisioner{})
+			_, err := longNameCr.ValidateUpdate(context.Background(), &longNameCr, &longNameCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.name cannot have a length greater than 50")))
 		})
 		ginkgo.It("Should not allow storagepool.path length > 255", func() {
-			_, err := longPathCr.ValidateUpdate(&HostPathProvisioner{})
+			_, err := longPathCr.ValidateUpdate(context.Background(), &longPathCr, &longPathCr)
 			gomega.Expect(err).To(gomega.BeEquivalentTo(fmt.Errorf("storagePool.path cannot have a length greater than 255")))
 		})
 	})


### PR DESCRIPTION
webhook validator interface is deprecated and replaced with CustomValidator interface.

```release-note
NONE
```

