### PR TITLE
Use backwards compatible "https" scheme string for prometheus

### DIFF
--- a/pkg/controller/hostpathprovisioner/prometheus.go
+++ b/pkg/controller/hostpathprovisioner/prometheus.go
@@ -265,7 +265,7 @@ func createPrometheusServiceMonitor(namespace string) *promv1.ServiceMonitor {
 			Endpoints: []promv1.Endpoint{
 				{
 					Port:   "metrics",
-					Scheme: ptr.To(promv1.SchemeHTTPS),
+					Scheme: ptr.To(promv1.Scheme("https")),
 					HTTPConfigWithProxyAndTLSFiles: promv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: promv1.HTTPConfigWithTLSFiles{
 							TLSConfig: &promv1.TLSConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Older prometheus complains about the (rather) new capital HTTP/HTTPS
```
ServiceMonitor.monitoring.coreos.com \"service-monitor-hpp\" is invalid: spec.endpoints[0].scheme: Unsupported value: \"HTTPS\": supported values: \"http\", \"https\"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

