### PR TITLE
fix: regex in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -48,9 +48,9 @@ function update_github_release() {
     cp deploy/*.yaml "$temp_dir/"
 
     # Update operator.yaml image tags to match the release tag (replace both 'latest' and version tags)
-    sed -i "s|quay.io/kubevirt/hostpath-provisioner-operator:\(latest\|v[0-9.]*\)|quay.io/kubevirt/hostpath-provisioner-operator:${TAG}|g" "$temp_dir/operator.yaml"
-    sed -i "s|quay.io/kubevirt/hostpath-provisioner:\(latest\|v[0-9.]*\)|quay.io/kubevirt/hostpath-provisioner:${TAG}|g" "$temp_dir/operator.yaml"
-    sed -i "s|quay.io/kubevirt/hostpath-csi-driver:\(latest\|v[0-9.]*\)|quay.io/kubevirt/hostpath-csi-driver:${TAG}|g" "$temp_dir/operator.yaml"
+    sed -i "s#quay.io/kubevirt/hostpath-provisioner-operator:\(latest\|v[0-9.]*\)#quay.io/kubevirt/hostpath-provisioner-operator:${TAG}#g" "$temp_dir/operator.yaml"
+    sed -i "s#quay.io/kubevirt/hostpath-provisioner:\(latest\|v[0-9.]*\)#quay.io/kubevirt/hostpath-provisioner:${TAG}#g" "$temp_dir/operator.yaml"
+    sed -i "s#quay.io/kubevirt/hostpath-csi-driver:\(latest\|v[0-9.]*\)#quay.io/kubevirt/hostpath-csi-driver:${TAG}#g" "$temp_dir/operator.yaml"
 
     gh release upload --repo "$GITHUB_REPOSITORY" --clobber "$TAG" \
         "$temp_dir"/*.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
release.sh script was not swapping out the image tags in the operator manifest due to an issue with the `sed` command using the `|` as it's delimiter. When sed does it's delimiter parsing on `:\(latest\|v[0-9.]*\)` it confuses the regex OR for a `|` literal making the statement evaluate to the literal string `latest|v` which fails to locate the correct image string

Fix for this is to use a new delimiter such as `#` so that `\|` can now resolve to the conditional OR.
 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

