### PR TITLE
Remove unused snapshotPath from StoragePool

### DIFF
--- a/deploy/hostpathprovisioner_overlay_csi_cr.yaml
+++ b/deploy/hostpathprovisioner_overlay_csi_cr.yaml
@@ -9,7 +9,6 @@ spec:
   storagePools:
     - name: "nfs-backend"
       path: "/nfs-vol"
-      snapshotPath: "/nfs-vol/snapshots"
       snapshotProvider: "reflink"
       pvcTemplate:
         accessModes:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -709,9 +709,6 @@ spec:
                             PersistentVolume backing this claim.
                           type: string
                       type: object
-                    snapshotPath:
-                      description: the path used to store snapshot volumes
-                      type: string
                     snapshotProvider:
                       description: SnapshotProvider defines the snapshot type, currently
                         only reflink supported

--- a/pkg/apis/hostpathprovisioner/v1beta1/types.go
+++ b/pkg/apis/hostpathprovisioner/v1beta1/types.go
@@ -64,8 +64,6 @@ type StoragePool struct {
 	PVCTemplate *corev1.PersistentVolumeClaimSpec `json:"pvcTemplate,omitempty" optional:"true"`
 	// the path to use on the host, this is a required field
 	Path string `json:"path" valid:"required"`
-	// the path used to store snapshot volumes
-	SnapshotPath *string `json:"snapshotPath,omitempty" optional:"true"`
 	// SnapshotProvider defines the snapshot type, currently only reflink supported
 	SnapshotProvider *string `json:"snapshotProvider,omitempty" optional:"true"`
 	// OverlayClassName is used to set the name of the overlay storage class

--- a/pkg/controller/hostpathprovisioner/controller_test.go
+++ b/pkg/controller/hostpathprovisioner/controller_test.go
@@ -547,7 +547,6 @@ func createStoragePoolWithRWXTemplate() *hppv1.HostPathProvisioner {
 				{
 					Name:             "testOverlayCSI",
 					Path:             "/tmp/test",
-					SnapshotPath:     ptr.To("tmp/test/snapshots"),
 					SnapshotProvider: ptr.To("reflink"),
 					PVCTemplate: &corev1.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,

--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -408,7 +408,6 @@ func getStoragePoolPaths(cr *hostpathprovisionerv1.HostPathProvisioner) []Storag
 			storagePoolPaths = append(storagePoolPaths, StoragePoolInfo{
 				Name:             storagePool.Name,
 				Path:             storagePool.Path,
-				SnapshotPath:     storagePool.SnapshotPath,
 				SnapshotProvider: storagePool.SnapshotProvider,
 				Shared:           isShared(storagePool.PVCTemplate),
 			})
@@ -432,12 +431,10 @@ func buildPathArgFromStoragePoolInfo(storagePools []StoragePoolInfo) string {
 		// We want to add /csi to the path so if we are running side by side with legacy provisioner
 		// the two paths don't mix.
 		storagePools[i].Path = filepath.Join(getMountNameFromStoragePool(storagePool.Name), "csi")
-		if storagePool.SnapshotPath != nil {
+		if storagePool.SnapshotProvider != nil {
 			path := filepath.Join(getMountNameFromStoragePool(storagePool.Name), "csi", "snapshots")
 			storagePools[i].SnapshotPath = &path
 		}
-		storagePools[i].SnapshotProvider = storagePool.SnapshotProvider
-		storagePools[i].Shared = storagePool.Shared
 	}
 	bytes, err := json.Marshal(storagePools)
 	if err != nil {

--- a/tools/helper/crd_generated.go
+++ b/tools/helper/crd_generated.go
@@ -1,8 +1,7 @@
 package helper
 
-//hppCRD is a string yaml of the hpp CRD
-var hppCRD string = 
-`apiVersion: apiextensions.k8s.io/v1
+// hppCRD is a string yaml of the hpp CRD
+var hppCRD string = `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -280,9 +279,6 @@ spec:
                             PersistentVolume backing this claim.
                           type: string
                       type: object
-                    snapshotPath:
-                      description: the path used to store snapshot volumes
-                      type: string
                     snapshotProvider:
                       description: SnapshotProvider defines the snapshot type, currently
                         only reflink supported


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`snapshotPath` in the storagePool API was not being used to create the snapshot directory, instead we were always creating a `snapshots/` directory within the RWX volume mount point. For snapshots to work and to be accessible across all nodes, they must exist within the shared mount path so it doesn't make sense to allow this path to be defined in the CR. Since it's currently unused and I don't think should be used, I think it should be removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove unused snapshotPath API
```

