### PR TITLE
Update operator deployment metrics port to 8443

### DIFF
--- a/tools/helper/network_policies.go
+++ b/tools/helper/network_policies.go
@@ -52,7 +52,7 @@ func newIngressToMetricsNP(namespace string) *networkv1.NetworkPolicy {
 				{
 					Ports: []networkv1.NetworkPolicyPort{
 						{
-							Port:     ptr.To(intstr.FromInt32(8080)),
+							Port:     ptr.To(intstr.FromInt32(8443)),
 							Protocol: ptr.To(corev1.ProtocolTCP),
 						},
 					},

--- a/tools/helper/operator_deployment_generated.go
+++ b/tools/helper/operator_deployment_generated.go
@@ -73,7 +73,7 @@ spec:
           periodSeconds: 5
         name: hostpath-provisioner-operator
         ports:
-        - containerPort: 8080
+        - containerPort: 8443
           name: metrics
           protocol: TCP
         readinessProbe:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We moved the metrics port use TLS, but never updated the port. This PR fixes the port.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

