### PR TITLE
Fix nil dereference in cleanDeployments when node is deleted

### DIFF
--- a/pkg/controller/hostpathprovisioner/storagepool.go
+++ b/pkg/controller/hostpathprovisioner/storagepool.go
@@ -146,6 +146,13 @@ func (r *ReconcileHostPathProvisioner) cleanDeployments(logger logr.Logger, cr *
 				if err != nil {
 					return err
 				}
+				if node == nil {
+					logger.V(3).Info("Node no longer exists, deleting deployment directly", "deployment", deployment.Name)
+					if err := r.client.Delete(context.TODO(), &deployment); err != nil && !errors.IsNotFound(err) {
+						return err
+					}
+					continue
+				}
 				desired := r.storagePoolDeploymentByNode(logger, cr, &storagePool, namespace, node)
 
 				// delete deployment

--- a/pkg/controller/hostpathprovisioner/storagepool_test.go
+++ b/pkg/controller/hostpathprovisioner/storagepool_test.go
@@ -164,6 +164,44 @@ var _ = ginkgo.Describe("Controller reconcile loop", func() {
 			gomega.Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(gomega.Equal(pointer.Bool(true)))
 		})
 
+		ginkgo.It("Should not panic when node is deleted before cleanup", func() {
+			cr, r, cl := createDeployedCr(createStoragePoolWithTemplateCr())
+			scaleClusterNodesAndDsUp(1, 1, cr, r, cl)
+			verifyDeploymentsAndPVCs(1, 1, cr, r, cl)
+
+			ginkgo.By("Deleting the node before marking CR for deletion")
+			removeNodesFromCluster(1, 1, cl)
+
+			ginkgo.By("Marking CR as deleted")
+			err := r.client.Get(context.TODO(), client.ObjectKeyFromObject(cr), cr)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			err = cl.Delete(context.TODO(), cr)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-name",
+					Namespace: testNamespace,
+				},
+			}
+			gomega.Expect(func() { _, err = r.Reconcile(context.TODO(), req) }).ToNot(gomega.Panic())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("Verifying deployments are cleaned up")
+			deploymentList := &appsv1.DeploymentList{}
+			err = cl.List(context.TODO(), deploymentList, &client.ListOptions{Namespace: testNamespace})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			for _, deployment := range deploymentList.Items {
+				gomega.Expect(metav1.IsControlledBy(&deployment, cr)).To(gomega.BeFalse())
+			}
+
+			ginkgo.By("Verifying no cleanup jobs are created for missing nodes")
+			jobList := &batchv1.JobList{}
+			err = r.client.List(context.TODO(), jobList)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(jobList.Items).To(gomega.BeEmpty())
+		})
+
 		ginkgo.It("Status length should remain at one with legacy CR", func() {
 			cr, r, cl := createDeployedCr(createLegacyCr())
 			err := cl.Get(context.TODO(), client.ObjectKeyFromObject(cr), cr)


### PR DESCRIPTION
**What this PR does / why we need it**:

When a Kubernetes node is removed before the HostPathProvisioner CR is deleted, `cleanDeployments` calls `createCleanupJobForDeployment`, which returns a nil node on `NotFound`. That nil node was then passed to `storagePoolDeploymentByNode`, which dereferenced `node.GetName()` and could panic.

This panic can interrupt reconciliation during deletion, prevent finalizer removal, and leave the CR stuck in `Terminating`.

This change adds a nil check in `cleanDeployments`. If the node is already gone, the deployment is deleted directly and cleanup job creation is skipped (the job cannot be scheduled on a deleted node anyway). A regression test is added to verify reconcile does not panic in this scenario.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>` format)_:
Fixes #

**Special notes for your reviewer**:
The other call site of `createCleanupJobForDeployment` in `reconcileStoragePools` discards the returned node (`_`), so this bug affects the deletion cleanup path in `cleanDeployments`.

**Release note**:

```release-note
NONE
```