### PR TITLE
Updated daemonset to serve metrics over HTTPS

### DIFF
--- a/pkg/controller/hostpathprovisioner/daemonset.go
+++ b/pkg/controller/hostpathprovisioner/daemonset.go
@@ -43,6 +43,7 @@ import (
 
 	hostpathprovisionerv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
 	"kubevirt.io/hostpath-provisioner-operator/pkg/util"
+	"kubevirt.io/hostpath-provisioner-operator/pkg/util/cryptopolicy"
 )
 
 const (
@@ -553,6 +554,28 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 									Name:  "VERSION",
 									Value: cr.Status.TargetVersion,
 								},
+								{
+									Name: "POD_IP",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "status.podIP",
+										},
+									},
+								},
+								{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.namespace",
+										},
+									},
+								},
+								{
+									Name:  "SERVICE_NAME",
+									Value: PrometheusServiceName,
+								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.BoolPtr(true),
@@ -564,6 +587,7 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 								"--nodeid=$(NODE_NAME)",
 								"--version=$(VERSION)",
 								"--datadir=$(PV_DIR)",
+								fmt.Sprintf("--metrics-tls-version=%s", cryptopolicy.GetTLSMinVersionString()),
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -572,7 +596,7 @@ func (r *ReconcileHostPathProvisioner) createCSIDaemonSetObject(cr *hostpathprov
 									Protocol:      corev1.ProtocolTCP,
 								},
 								{
-									ContainerPort: 8080,
+									ContainerPort: 8443,
 									Name:          "metrics",
 									Protocol:      corev1.ProtocolTCP,
 								},

--- a/pkg/controller/hostpathprovisioner/daemonset_test.go
+++ b/pkg/controller/hostpathprovisioner/daemonset_test.go
@@ -18,6 +18,7 @@ package hostpathprovisioner
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hppv1 "kubevirt.io/hostpath-provisioner-operator/pkg/apis/hostpathprovisioner/v1beta1"
+	"kubevirt.io/hostpath-provisioner-operator/pkg/util/cryptopolicy"
 	"kubevirt.io/hostpath-provisioner-operator/version"
 )
 
@@ -40,6 +42,17 @@ const (
 	localDataDir                     = "local-data-dir"
 	hashedLongStoragePoolNameDataDir = "l12345678901234567890123456789012345678901234-69d4290d-data-dir"
 )
+
+// findEnvVar finds an environment variable by name in a container's env list.
+// Returns the EnvVar if found, nil otherwise.
+func findEnvVar(container *corev1.Container, name string) *corev1.EnvVar {
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			return &container.Env[i]
+		}
+	}
+	return nil
+}
 
 var _ = ginkgo.Describe("Controller reconcile loop", func() {
 	ginkgo.Context("daemonset", func() {
@@ -217,7 +230,7 @@ var _ = ginkgo.Describe("Controller reconcile loop", func() {
 			ginkgo.Entry("longNamecr", createStoragePoolWithTemplateLongNameCr(), hashedLongStoragePoolNameDataDir),
 		)
 
-		ginkgo.DescribeTable("DaemonSet should have prometheus labels, port", func(cr *hppv1.HostPathProvisioner) {
+		ginkgo.DescribeTable("DaemonSet should have prometheus labels, port, and TLS env vars", func(cr *hppv1.HostPathProvisioner) {
 			_, r, cl = createDeployedCr(cr)
 			ds := &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -228,14 +241,40 @@ var _ = ginkgo.Describe("Controller reconcile loop", func() {
 			dsNN := client.ObjectKeyFromObject(ds)
 			err := cl.Get(context.TODO(), dsNN, ds)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Check metrics port
 			port := corev1.ContainerPort{
-				ContainerPort: 8080,
+				ContainerPort: 8443,
 				Name:          "metrics",
 				Protocol:      corev1.ProtocolTCP,
 			}
 			gomega.Expect(ds.Spec.Template.Spec.Containers[0].Ports).To(gomega.ContainElement(port))
+
+			// Check prometheus labels
 			gomega.Expect(ds.Labels[PrometheusLabelKey]).To(gomega.Equal(PrometheusLabelValue))
 			gomega.Expect(ds.Spec.Template.Labels[PrometheusLabelKey]).To(gomega.Equal(PrometheusLabelValue))
+
+			// Check TLS-related environment variables
+			container := &ds.Spec.Template.Spec.Containers[0]
+
+			// Verify POD_IP env var source
+			podIPEnv := findEnvVar(container, "POD_IP")
+			gomega.Expect(podIPEnv).NotTo(gomega.BeNil())
+			gomega.Expect(podIPEnv.ValueFrom).NotTo(gomega.BeNil())
+			gomega.Expect(podIPEnv.ValueFrom.FieldRef).NotTo(gomega.BeNil())
+			gomega.Expect(podIPEnv.ValueFrom.FieldRef.FieldPath).To(gomega.Equal("status.podIP"))
+
+			// Verify POD_NAMESPACE env var source
+			podNamespaceEnv := findEnvVar(container, "POD_NAMESPACE")
+			gomega.Expect(podNamespaceEnv).NotTo(gomega.BeNil())
+			gomega.Expect(podNamespaceEnv.ValueFrom).NotTo(gomega.BeNil())
+			gomega.Expect(podNamespaceEnv.ValueFrom.FieldRef).NotTo(gomega.BeNil())
+			gomega.Expect(podNamespaceEnv.ValueFrom.FieldRef.FieldPath).To(gomega.Equal("metadata.namespace"))
+
+			// Verify SERVICE_NAME env var value
+			serviceNameEnv := findEnvVar(container, "SERVICE_NAME")
+			gomega.Expect(serviceNameEnv).NotTo(gomega.BeNil())
+			gomega.Expect(serviceNameEnv.Value).To(gomega.Equal(PrometheusServiceName))
 		},
 			ginkgo.Entry("legacyCr", createLegacyCr()),
 			ginkgo.Entry("legacyStoragePoolCr", createLegacyStoragePoolCr()),
@@ -439,5 +478,45 @@ var _ = ginkgo.Describe("Controller reconcile loop", func() {
 			ginkgo.Entry("legacyDs", MultiPurposeHostPathProvisionerName),
 			ginkgo.Entry("csiDs", fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName)),
 		)
+
+		ginkgo.Context("metrics TLS configuration", func() {
+			ginkgo.BeforeEach(func() {
+				// Clear env vars to ensure deterministic test behavior
+				os.Unsetenv("TLS_MIN_VERSION")
+				os.Unsetenv("TLS_MIN_VERSION_OVERRIDE")
+			})
+
+			ginkgo.AfterEach(func() {
+				// Clean up env vars after test
+				os.Unsetenv("TLS_MIN_VERSION")
+				os.Unsetenv("TLS_MIN_VERSION_OVERRIDE")
+			})
+
+			ginkgo.It("Should include --metrics-tls-version argument in CSI daemonset", func() {
+				_, _, cl := createDeployedCr(createLegacyCr())
+				ds := &appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-csi", MultiPurposeHostPathProvisionerName),
+						Namespace: testNamespace,
+					},
+				}
+				err := cl.Get(context.TODO(), client.ObjectKeyFromObject(ds), ds)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify --metrics-tls-version argument is present and matches current policy
+				container := ds.Spec.Template.Spec.Containers[0]
+				expectedArg := fmt.Sprintf("--metrics-tls-version=%s", cryptopolicy.GetTLSMinVersionString())
+				foundArg := false
+				for _, arg := range container.Args {
+					if strings.HasPrefix(arg, "--metrics-tls-version=") {
+						foundArg = true
+						gomega.Expect(arg).To(gomega.Equal(expectedArg))
+						break
+					}
+				}
+				gomega.Expect(foundArg).To(gomega.BeTrue(), "Expected --metrics-tls-version argument not found")
+			})
+		})
+
 	})
 })

--- a/pkg/util/cryptopolicy/cryptopolicy.go
+++ b/pkg/util/cryptopolicy/cryptopolicy.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	ocpconfigv1 "github.com/openshift/api/config/v1"
+	"k8s.io/klog/v2"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -83,6 +84,46 @@ func getTLSVersion(versionName string) *uint16 {
 	}
 
 	return nil
+}
+
+// GetTLSMinVersionString returns the TLS minimum version string to use based on environment variables.
+// It checks environment variables in this order:
+//  1. TLS_MIN_VERSION_OVERRIDE (manual override)
+//  2. TLS_MIN_VERSION (set by APIServer watch on OpenShift)
+//  3. Default: VersionTLS13
+//
+// Returns a string like "VersionTLS13" suitable for passing to command-line arguments.
+// This ensures consistent precedence logic across the operator and daemonset configuration.
+// If an invalid value is provided, it logs a warning and returns the default.
+//
+// Note: TLS_MIN_VERSION is set by handleAPIServerFunc when watching APIServer resources,
+// which may not have run yet during the first DaemonSet reconcile. In that case, the
+// DaemonSet will initially be created with the default (VersionTLS13), and will be
+// updated on a subsequent reconcile after the APIServer watch fires. This is normal
+// self-healing behavior and ensures secure defaults.
+func GetTLSMinVersionString() string {
+	// Check for override first
+	if tlsVersion := os.Getenv("TLS_MIN_VERSION_OVERRIDE"); tlsVersion != "" {
+		// Validate using existing getTLSVersion function
+		if getTLSVersion(tlsVersion) == nil {
+			klog.Warningf("Invalid TLS_MIN_VERSION_OVERRIDE value '%s', defaulting to VersionTLS13. Valid values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13", tlsVersion)
+			return "VersionTLS13"
+		}
+		return tlsVersion
+	}
+
+	// Then fall back to cluster settings
+	if tlsVersion := os.Getenv("TLS_MIN_VERSION"); tlsVersion != "" {
+		// Validate using existing getTLSVersion function
+		if getTLSVersion(tlsVersion) == nil {
+			klog.Warningf("Invalid TLS_MIN_VERSION value '%s', defaulting to VersionTLS13. Valid values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13", tlsVersion)
+			return "VersionTLS13"
+		}
+		return tlsVersion
+	}
+
+	// Default to TLS 1.3 if no environment variable is set
+	return "VersionTLS13"
 }
 
 func cipherSuitesIDs(names []string) []uint16 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updated the daemonset to serve metrics over HTTPS. Added optional parameters to configure the TLS on the metrics server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Daemonset now uses TLS for metrics
```

