### PR TITLE
Fix mounter crash when there are multiple mount entries

### DIFF
--- a/cmd/mounter/main.go
+++ b/cmd/mounter/main.go
@@ -385,8 +385,5 @@ func filterGlobalMounts(infos []FindmntInfo) []FindmntInfo {
 			globalMounts = append(globalMounts, info)
 		}
 	}
-	if len(globalMounts) == 0 {
-		return infos
-	}
 	return globalMounts
 }

--- a/cmd/mounter/main.go
+++ b/cmd/mounter/main.go
@@ -277,9 +277,18 @@ func mountIfNotMounted(targetPath, hostPath, hostMountPath string) {
 			if err != nil {
 				panic(err)
 			}
-			if len(infos) != 1 {
-				log.Info("Number of infos is not 1", "count", len(infos))
+			if len(infos) == 0 {
+				log.Info("No mount info found for source", "source", hostMountPath)
 				os.Exit(1)
+			}
+			if len(infos) > 1 {
+				log.Info("Multiple mount infos found, filtering for pod mount", "count", len(infos))
+				filtered := filterPodMounts(infos)
+				if len(filtered) != 1 {
+					log.Info("Unable to determine unique pod mount", "count", len(filtered))
+					os.Exit(1)
+				}
+				infos = filtered
 			}
 			log.Info("Found host path by source", "path", infos[0].Target)
 			hostMountPath = string(infos[0].Target)
@@ -364,4 +373,20 @@ func (f *FindmntInfo) GetOptions() []string {
 // GetSourceDevice returns the path to the device /dev/<device>
 func (b *DeviceInfo) GetSourceDevice() string {
 	return filepath.Join("dev", b.Name)
+}
+
+// filterPodMounts filters mount infos to only include pod volume mounts,
+// excluding CSI driver global mounts. This handles storage providers like
+// CephFS that create both a global mount and a per-pod bind mount.
+func filterPodMounts(infos []FindmntInfo) []FindmntInfo {
+	var podMounts []FindmntInfo
+	for _, info := range infos {
+		if strings.Contains(info.Target, "/pods/") {
+			podMounts = append(podMounts, info)
+		}
+	}
+	if len(podMounts) == 0 {
+		return infos
+	}
+	return podMounts
 }

--- a/cmd/mounter/main.go
+++ b/cmd/mounter/main.go
@@ -282,10 +282,10 @@ func mountIfNotMounted(targetPath, hostPath, hostMountPath string) {
 				os.Exit(1)
 			}
 			if len(infos) > 1 {
-				log.Info("Multiple mount infos found, filtering for pod mount", "count", len(infos))
-				filtered := filterPodMounts(infos)
+				log.Info("Multiple mount infos found, filtering for global CSI mount", "count", len(infos))
+				filtered := filterGlobalMounts(infos)
 				if len(filtered) != 1 {
-					log.Info("Unable to determine unique pod mount", "count", len(filtered))
+					log.Info("Unable to determine unique global mount", "count", len(filtered))
 					os.Exit(1)
 				}
 				infos = filtered
@@ -375,18 +375,18 @@ func (b *DeviceInfo) GetSourceDevice() string {
 	return filepath.Join("dev", b.Name)
 }
 
-// filterPodMounts filters mount infos to only include pod volume mounts,
-// excluding CSI driver global mounts. This handles storage providers like
-// CephFS that create both a global mount and a per-pod bind mount.
-func filterPodMounts(infos []FindmntInfo) []FindmntInfo {
-	var podMounts []FindmntInfo
+// filterGlobalMounts filters mount infos to only include CSI global mounts,
+// excluding per-pod bind mounts. This handles storage providers like CephFS
+// that create both a global mount and a per-pod bind mount.
+func filterGlobalMounts(infos []FindmntInfo) []FindmntInfo {
+	var globalMounts []FindmntInfo
 	for _, info := range infos {
-		if strings.Contains(info.Target, "/pods/") {
-			podMounts = append(podMounts, info)
+		if strings.Contains(info.Target, "/globalmount") {
+			globalMounts = append(globalMounts, info)
 		}
 	}
-	if len(podMounts) == 0 {
+	if len(globalMounts) == 0 {
 		return infos
 	}
-	return podMounts
+	return globalMounts
 }

--- a/cmd/mounter/mounter_test.go
+++ b/cmd/mounter/mounter_test.go
@@ -21,6 +21,50 @@ import (
 )
 
 var _ = ginkgo.Describe("Mounter tests", func() {
+	ginkgo.Context("filterPodMounts", func() {
+		ginkgo.It("should filter to pod mount when multiple mounts exist", func() {
+			infos := []FindmntInfo{
+				{
+					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/openshift-storage.cephfs.csi.ceph.com/abc123/globalmount",
+					Source: "csi-cephfs-node@cluster.cephfs=/volumes/csi/csi-vol-123/abc",
+				},
+				{
+					Target: "/var/lib/kubelet/pods/pod-uid-123/volumes/kubernetes.io~csi/pvc-abc/mount",
+					Source: "csi-cephfs-node@cluster.cephfs=/volumes/csi/csi-vol-123/abc",
+				},
+			}
+			result := filterPodMounts(infos)
+			gomega.Expect(result).To(gomega.HaveLen(1))
+			gomega.Expect(result[0].Target).To(gomega.ContainSubstring("/pods/"))
+		})
+
+		ginkgo.It("should return all infos when no pod mount is found", func() {
+			infos := []FindmntInfo{
+				{
+					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/driver/globalmount",
+					Source: "some-source",
+				},
+				{
+					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/driver/other",
+					Source: "some-source",
+				},
+			}
+			result := filterPodMounts(infos)
+			gomega.Expect(result).To(gomega.HaveLen(2))
+		})
+
+		ginkgo.It("should return single pod mount unchanged", func() {
+			infos := []FindmntInfo{
+				{
+					Target: "/var/lib/kubelet/pods/pod-uid/volumes/kubernetes.io~csi/pvc-123/mount",
+					Source: "nfs-server:/share",
+				},
+			}
+			result := filterPodMounts(infos)
+			gomega.Expect(result).To(gomega.HaveLen(1))
+		})
+	})
+
 	ginkgo.Context("lsblk JSON parsing", func() {
 		intJSON := `{
 			"blockdevices": [

--- a/cmd/mounter/mounter_test.go
+++ b/cmd/mounter/mounter_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 var _ = ginkgo.Describe("Mounter tests", func() {
-	ginkgo.Context("filterPodMounts", func() {
-		ginkgo.It("should filter to pod mount when multiple mounts exist", func() {
+	ginkgo.Context("filterGlobalMounts", func() {
+		ginkgo.It("should filter to global mount when multiple mounts exist", func() {
 			infos := []FindmntInfo{
 				{
 					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/openshift-storage.cephfs.csi.ceph.com/abc123/globalmount",
@@ -33,34 +33,34 @@ var _ = ginkgo.Describe("Mounter tests", func() {
 					Source: "csi-cephfs-node@cluster.cephfs=/volumes/csi/csi-vol-123/abc",
 				},
 			}
-			result := filterPodMounts(infos)
+			result := filterGlobalMounts(infos)
 			gomega.Expect(result).To(gomega.HaveLen(1))
-			gomega.Expect(result[0].Target).To(gomega.ContainSubstring("/pods/"))
+			gomega.Expect(result[0].Target).To(gomega.ContainSubstring("/globalmount"))
 		})
 
-		ginkgo.It("should return all infos when no pod mount is found", func() {
+		ginkgo.It("should return all infos when no global mount is found", func() {
 			infos := []FindmntInfo{
 				{
-					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/driver/globalmount",
+					Target: "/var/lib/kubelet/pods/pod-uid-1/volumes/kubernetes.io~csi/pvc-1/mount",
 					Source: "some-source",
 				},
 				{
-					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/driver/other",
+					Target: "/var/lib/kubelet/pods/pod-uid-2/volumes/kubernetes.io~csi/pvc-2/mount",
 					Source: "some-source",
 				},
 			}
-			result := filterPodMounts(infos)
+			result := filterGlobalMounts(infos)
 			gomega.Expect(result).To(gomega.HaveLen(2))
 		})
 
-		ginkgo.It("should return single pod mount unchanged", func() {
+		ginkgo.It("should return single global mount unchanged", func() {
 			infos := []FindmntInfo{
 				{
-					Target: "/var/lib/kubelet/pods/pod-uid/volumes/kubernetes.io~csi/pvc-123/mount",
+					Target: "/var/lib/kubelet/plugins/kubernetes.io/csi/driver/abc123/globalmount",
 					Source: "nfs-server:/share",
 				},
 			}
-			result := filterPodMounts(infos)
+			result := filterGlobalMounts(infos)
 			gomega.Expect(result).To(gomega.HaveLen(1))
 		})
 	})

--- a/cmd/mounter/mounter_test.go
+++ b/cmd/mounter/mounter_test.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("Mounter tests", func() {
 			gomega.Expect(result[0].Target).To(gomega.ContainSubstring("/globalmount"))
 		})
 
-		ginkgo.It("should return all infos when no global mount is found", func() {
+		ginkgo.It("should return empty when no global mount is found", func() {
 			infos := []FindmntInfo{
 				{
 					Target: "/var/lib/kubelet/pods/pod-uid-1/volumes/kubernetes.io~csi/pvc-1/mount",
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("Mounter tests", func() {
 				},
 			}
 			result := filterGlobalMounts(infos)
-			gomega.Expect(result).To(gomega.HaveLen(2))
+			gomega.Expect(result).To(gomega.BeEmpty())
 		})
 
 		ginkgo.It("should return single global mount unchanged", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some storage providers (like CephFS) create both a global CSI mount and a per-pod bind mount for the same source. The mounter expected exactly one findmnt result and exited when it found two. Filter for the global CSI mount instead of failing.

  - **Before**: `findMntBySource` returns 2 CephFS mounts (global + pod bind mount), code sees len != 1, exits.
  - **After**: When multiple mounts are found, `filterGlobalMounts` picks the one containing `/globalmount` (the CSI global mount path), skipping per-pod bind mounts under` /var/lib/kubelet/pods/`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://redhat.atlassian.net/browse/CNV-89466

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix mounter crash when there are multiple mount entries
```

