### PR TITLE
Enable readOnlyRootFilesystem for hostpath-provisioner-operator container

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2014,6 +2014,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds readOnlyRootFilesystem: true to the hostpath-provisioner-operator container SecurityContext in deploy/operator.yaml.
No emptyDir /tmp volume is needed because:
- The webhook TLS certs are already mounted from a Secret at /tmp/k8s-webhook-server/serving-certs
- The operator process does not perform any filesystem writes

The CSI DaemonSet containers are not modified because they run with Privileged: true, where readOnlyRootFilesystem provides no security benefit and would break runtime writes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
No unit tests have been added because the changes are related to a static yaml file.
The e2e test verifying this change at runtime will be submitted as a separate PR in the `kubevirt/hostpath-provisioner` repository, since functional tests for the operator live there.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable readOnlyRootFilesystem for the hostpath-provisioner-operator container
```

